### PR TITLE
Compatibility Fixes

### DIFF
--- a/channels/icefilm.ch
+++ b/channels/icefilm.ch
@@ -7,8 +7,8 @@ folder {
            order=url
            type=empty
            media {
-           #<div class="down_butt_pad1" style="display:none;" id="downloadlink"><a href="http://www820.megaupload.com/files/e852a3a714538767347d5866d6ad9d7c/big_bang_theory.1x01.dvdrip_xvid-fov.H2020.dvd4arab.com.avi" class="down_butt1"></a>
-           matcher=<div class=\"down_butt_pad1\" style=\"display:none;\" id=\"downloadlink\"><a href="([^\"]+)" 
+           #<a href="http://www.megavideo.com/?d=429EF48Q" class="mvlink" target="_blank">View on Megavideo</a>
+           matcher=<a href="([^\"]+)\"\s+class=\"mvlink\"
           order=url
            }
       }

--- a/channels/icefilms.ch
+++ b/channels/icefilms.ch
@@ -67,7 +67,7 @@ macrodef movieMacro {
 	}
 }
 
-channel IceFilm {
+channel IceFilms {
    img=http://img.icefilms.info/logo.png
    folder {
       name=TV Shows

--- a/scripts/pplive.groovy
+++ b/scripts/pplive.groovy
@@ -1,11 +1,13 @@
 script {
+    PPLIVE = 'C:\\Program Files (x86)\\PPLive\\PPTV\\PPLive.exe'
+
     profile ('PPLive') {
         pattern {
            protocol 'synacast'
         }
 
         action {
-            $HOOK = "C:\\Program Files (x86)\\PPLive\\PPTV\\PPLive.exe ${$URI}"
+            $HOOK = "$PPLIVE \"${$URI}\""
             $URI = 'http://127.0.0.1:8888'
         }
     }

--- a/scripts/rtmp.groovy
+++ b/scripts/rtmp.groovy
@@ -1,15 +1,16 @@
 script {
-	profile ('RTMP(E)') {
-		pattern {
-			protocol ([ 'rtmp', 'rtmpe' ])
-		}
+    RTMPDUMP = 'C:\\rtmpdump.exe'
 
-		action {
-			$URI = "\""+$URI+"\""
-			def $X=$URI.split("!!!pms_ch_dash_y!!!") as String[]
-			if($X.length>1)
-				$URI=$X[0]+"\""+" -y \""+$X[1]
-			$DOWNLOADER = "C:\\rtmpdump.exe -o $DOWNLOADER_OUT -r ${$URI}"
-		}
-	}
+    profile ('RTMP(E)') {
+        pattern {
+            protocol ([ 'rtmp', 'rtmpe' ])
+        }
+
+        action {
+            def strings = $URI.split('!!!pms_ch_dash_y!!!')
+            if (strings.length > 1)
+                $URI = strings[0] + '" -y "' + strings[1]
+            $DOWNLOADER = "$RTMPDUMP -o $DOWNLOADER_OUT -r \"${$URI}\""
+        }
+    }
 }

--- a/src/no/geosoft/cc/io/FileListener.java
+++ b/src/no/geosoft/cc/io/FileListener.java
@@ -1,0 +1,36 @@
+/*
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public 
+ * License as published by the Free Software Foundation; either 
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this program; if not, write to the Free 
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, 
+ * MA  02111-1307, USA.
+ */
+package no.geosoft.cc.io;
+
+import java.io.File;
+
+/**
+ * Interface for listening to disk file changes.
+ * @see FileMonitor
+ * 
+ * @author <a href="mailto:jacob.dreyer@geosoft.no">Jacob Dreyer</a>
+ */   
+public interface FileListener
+{
+  /**
+   * Called when one of the monitored files are created, deleted
+   * or modified.
+   * 
+   * @param file  File which has been changed.
+   */
+  void fileChanged (File file);
+}

--- a/src/no/geosoft/cc/io/FileMonitor.java
+++ b/src/no/geosoft/cc/io/FileMonitor.java
@@ -1,0 +1,171 @@
+/*
+ * This code is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
+ * MA  02111-1307, USA.
+ */
+package no.geosoft.cc.io;
+
+import java.util.*;
+import java.io.File;
+import java.lang.ref.WeakReference;
+
+/**
+ * Class for monitoring changes in disk files.
+ * Usage:
+ *
+ *    1. Implement the FileListener interface.
+ *    2. Create a FileMonitor instance.
+ *    3. Add the file(s)/directory(ies) to listen for.
+ *
+ * fileChanged() will be called when a monitored file is created,
+ * deleted or its modified time changes.
+ *
+ * @author <a href="mailto:jacob.dreyer@geosoft.no">Jacob Dreyer</a>
+ */
+public class FileMonitor
+{
+    private Timer       timer_;
+    private HashMap     files_;       // File -> Long
+    private Collection  listeners_;   // of WeakReference(FileListener)
+
+    /**
+     * Create a file monitor instance with specified polling interval.
+     *
+     * @param pollingInterval  Polling interval in milli seconds.
+     */
+    public FileMonitor (long pollingInterval)
+    {
+        files_     = new HashMap();
+        listeners_ = new ArrayList();
+        timer_ = new Timer (true);
+        timer_.schedule (new FileMonitorNotifier(), 0, pollingInterval);
+    }
+
+    /**
+     * Stop the file monitor polling.
+     */
+    public void stop()
+    {
+        timer_.cancel();
+    }
+
+    /**
+     * Add file to listen for. File may be any java.io.File (including a
+     * directory) and may well be a non-existing file in the case where the
+     * creating of the file is to be trepped.
+     * <p>
+     * More than one file can be listened for. When the specified file is
+     * created, modified or deleted, listeners are notified.
+     *
+     * @param file  File to listen for.
+     */
+    public void addFile (File file)
+    {
+        if (!files_.containsKey (file)) {
+            long modifiedTime = file.exists() ? file.lastModified() : -1;
+            files_.put (file, new Long (modifiedTime));
+        }
+    }
+
+    /**
+     * Remove specified file for listening.
+     *
+     * @param file  File to remove.
+     */
+    public void removeFile (File file)
+    {
+        files_.remove (file);
+    }
+
+    /**
+     * Add listener to this file monitor.
+     *
+     * @param fileListener  Listener to add.
+     */
+    public void addListener (FileListener fileListener)
+    {
+        // Don't add if its already there
+        for (Iterator i = listeners_.iterator(); i.hasNext(); ) {
+            WeakReference reference = (WeakReference) i.next();
+            FileListener listener = (FileListener) reference.get();
+            if (listener == fileListener)
+                return;
+        }
+
+        // Use WeakReference to avoid memory leak if this becomes the
+        // sole reference to the object.
+        listeners_.add (new WeakReference (fileListener));
+    }
+
+    /**
+     * Remove listener from this file monitor.
+     *
+     * @param fileListener  Listener to remove.
+     */
+    public void removeListener (FileListener fileListener)
+    {
+        for (Iterator i = listeners_.iterator(); i.hasNext(); ) {
+            WeakReference reference = (WeakReference) i.next();
+            FileListener listener = (FileListener) reference.get();
+            if (listener == fileListener) {
+                i.remove();
+                break;
+            }
+        }
+    }
+
+    /**
+     * This is the timer thread which is executed every n milliseconds
+     * according to the setting of the file monitor. It investigates the
+     * file in question and notify listeners if changed.
+     */
+    private class FileMonitorNotifier extends TimerTask
+    {
+        public void run()
+        {
+            // Loop over the registered files and see which have changed.
+            // Use a copy of the list in case listener wants to alter the
+            // list within its fileChanged method.
+            Collection files = new ArrayList (files_.keySet());
+
+            for (Iterator i = files.iterator(); i.hasNext(); ) {
+                File file = (File) i.next();
+                long lastModifiedTime = ((Long) files_.get (file)).longValue();
+                long newModifiedTime  = file.exists() ? file.lastModified() : -1;
+
+                // Chek if file has changed
+                if (newModifiedTime != lastModifiedTime) {
+
+                    // Notify listeners
+                    for (Iterator j = listeners_.iterator(); j.hasNext(); ) {
+                        WeakReference reference = (WeakReference) j.next();
+                        FileListener listener = (FileListener) reference.get();
+
+                        // Remove from list if the back-end object has been GC'd
+                        if (listener == null)
+                            j.remove();
+                        else {
+                            listener.fileChanged (file);
+                        }
+                    }
+
+                    // chocolateboy 2010-12-21: don't update the mtime until *after* the callback
+                    // Register new modified time
+                    long finalModifiedTime = file.exists() ? file.lastModified() : -1;
+                    files_.put (file, new Long (finalModifiedTime));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch a) makes the IceFilms channel compatible with PMSEncoder b) cleans up the PMSEncoder scripts and c) adds a missing dependency. The latter is needed because Channel can be loaded before PMSEncoder (this happens if the pms-mlx extension is used). More work needs to be done to remove the dependency on PMSEncoder (i.e. remove the WEB stuff), but that can be discussed/implemented later.
