### PR TITLE
Updated deprecated calls

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
-	<classpathentry kind="lib" path="C:/Program Files (x86)/PS3 Media Server/pms.jar"/>
-	<classpathentry kind="lib" path="C:/Program Files (x86)/PS3 Media Server/plugins/pmsencoder-1.3.0.jar"/>
-	<classpathentry kind="output" path="bin"/>
-</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 **.orig
+/.classpath

--- a/src/com/sharkhunter/channel/ChannelAuth.java
+++ b/src/com/sharkhunter/channel/ChannelAuth.java
@@ -1,16 +1,14 @@
 package com.sharkhunter.channel;
 
-import java.net.Proxy;
-
 public class ChannelAuth {
 	public int method;
 	public String authStr;
 	public long ttd;
 	public ChannelProxy proxy;
-	
+
 	public ChannelAuth() {
 	}
-	
+
 	public ChannelAuth(ChannelAuth a) {
 		method=a.method;
 		authStr=a.authStr;

--- a/src/com/sharkhunter/channel/ChannelCfg.java
+++ b/src/com/sharkhunter/channel/ChannelCfg.java
@@ -19,11 +19,11 @@ import com.sun.jna.Platform;
 import net.pms.PMS;
 
 public class ChannelCfg {
-	
+
 	public static final int PROXY_DNS_NONE=0;
 	public static final int PROXY_DNS_ALL=1;
 	public static final int PROXY_DNS_CHANNEL=2;
-	
+
 	private String chPath;
 	private String saPath;
 	private String rtmpPath;
@@ -65,7 +65,7 @@ public class ChannelCfg {
 	private String badUrl;
 	private boolean subBravia;
 	private boolean clearCookies;
-	
+
 	public ChannelCfg(Channels top) {
 		chPath=null;
 		saPath=null;
@@ -104,59 +104,59 @@ public class ChannelCfg {
 		subBravia=true;
 		clearCookies=false;
 	}
-	
+
 	///////////////////////////////////
 	// Set methods
 	///////////////////////////////////
-	
+
 	public void setPath(String p) {
 		chPath=p;
 	}
-	
+
 	public void setSavePath(String p) {
 		saPath=p;
 	}
-	
+
 	public void setRtmpPath(String p) {
 		rtmpPath=p;
 	}
-	
+
 	public void setScriptPath(String p) {
 		scriptPath=p;
 	}
-	
+
 	public void setSopPath(String p) {
 		sopcastPath=p;
 	}
-	
+
 	public void setPPLivePath(String p) {
 		pplivePath=p;
 	}
-	
+
 	public void setPerlPath(String p) {
 		perlPath=p;
 	}
-	
+
 	public void setPythPath(String p) {
 		pythonPath=p;
 	}
-	
+
 	public void setGetFlPath(String p) {
 		get_flPath=p;
 	}
-	
+
 	public void setYouTubePath(String p) {
 		ytPath=p;
 	}
-	
+
 	public void setCookiePath(String p) {
 		cookiePath=p;
 	}
-	
+
 	public void setCredPath(String p) {
 		credPath=p;
 	}
-	
+
 	public void setNaviXUpload(String p) {
 		String[] tmp=p.split(",");
 		navixUploadList=p;
@@ -166,41 +166,41 @@ public class ChannelCfg {
 			navixUploadList2=tmp[1];
 		}
 	}
-	
+
 	public void setFavorite(boolean b) {
 		favorite=b;
 	}
-	
+
 	public void setLongSvaeName(boolean b) {
 		longSaveName=b;
 	}
-	
+
 	public void setCrawl(boolean b) {
 		crawl=b;
 	}
-	
+
 	public void setCrawlFL(String str) {
 		setCrawlFL(ChannelCrawl.parseCrawlMode(ChannelCrawl.CRAWL_FLA, str));
 	}
-	
+
 	public void setCrawlFL(int t) {
 		if(t!=ChannelCrawl.CRAWL_UNKNOWN)
 			crawlFL=t;
 	}
-	
+
 	public void setCrawlHL(String str) {
 		setCrawlHL(ChannelCrawl.parseCrawlMode(ChannelCrawl.CRAWL_HML, str));
 	}
-	
+
 	public void setCrawlHL(int t) {
 		if(t!=ChannelCrawl.CRAWL_UNKNOWN)
 			crawlHL=t;
 	}
-	
+
 	public void setStdAlone(boolean b) {
 		stdAlone=b;
 	}
-	
+
 	////////////////////////////////////////
 	// Get methods
 	////////////////////////////////////////
@@ -208,175 +208,175 @@ public class ChannelCfg {
 	public String getPath() {
 		return chPath;
 	}
-	
+
 	public String getSavePath() {
 		return saPath;
 	}
-	
+
 	public String getRtmpPath() {
 		return rtmpPath;
 	}
-	
+
 	public String getScriptPath() {
 		return scriptPath;
 	}
-	
+
 	public String getSopPath() {
 		return sopcastPath;
 	}
-	
+
 	public String getPPLivePath() {
 		return pplivePath;
 	}
-	
+
 	public String getPerlPath() {
 		return perlPath;
 	}
-	
+
 	public String getPythonPath() {
 		return pythonPath;
 	}
-	
+
 	public String getFlashPath() {
 		if(ChannelUtil.empty(get_flPath))
 			return getScriptPath();
 		return get_flPath;
 	}
-	
+
 	public String getYouTubePath() {
 		if(ChannelUtil.empty(ytPath))
 			return getScriptPath();
 		return ytPath;
 	}
-	
+
 	public boolean getCache() {
 		return cache;
 	}
-	
+
 	public String getCookiePath() {
 		return cookiePath;
 	}
-	
+
 	public String getCredPath() {
 		return credPath;
 	}
-	
+
 	public boolean favorite() {
 		return favorite;
 	}
-	
+
 	public String getNaviXUpload() {
 		return navixUploadList;
 	}
-	
+
 	public String getNaviXUpload2() {
 		return navixUploadList2;
 	}
-	
+
 	public boolean noPlay() {
 		return noPlay;
 	}
-	
+
 	public boolean netDiscStyle() {
 		return netDisc;
 	}
-	
+
 	public boolean rawSave() {
 		return rawSave;
 	}
-	
+
 	public boolean allPlay() {
 		return allPlay;
 	}
-	
+
 	public int proxyDNSMode() {
 		return proxyDNSMode;
 	}
-	
+
 	public String proxyDNS() {
 		return proxyDNS;
 	}
-	
+
 	public boolean longSaveName() {
 		return longSaveName;
 	}
-	
+
 	public boolean oldSub() {
 		return oldSub;
 	}
-	
+
 	public String getCurlPath() {
 		return (String) PMS.getConfiguration().getCustomProperty("curl.path");
 	}
-	
+
 	public boolean mp2Force() {
 		return mp2force;
 	}
-	
+
 	public boolean fileBuffer() {
 		return fileBuffer;
 	}
-	
+
 	public int getCrawlHLMode() {
 		return crawlHL;
 	}
-	
+
 	public int getCrawlFLMode() {
 		return crawlFL;
 	}
-	
+
 	public String getCrawlFormat() {
 		return crawlFormat;
 	}
-	
+
 	public boolean crawl() {
 		return crawl;
 	}
-	
+
 	public boolean stdAlone() {
 		return stdAlone;
-	}	
-	
+	}
+
 	public boolean monitor() {
 		return monitor;
 	}
-	
+
 	public boolean usePMSEncoder() {
 		return pmsenc;
 	}
-	
+
 	public boolean useStreamVar() {
 		return streamVar;
 	}
-	
+
 	public String nullURL() {
 		return nullUrl;
 	}
-	
+
 	public String badURL() {
 		return badUrl;
 	}
-	
+
 	public boolean subBravia() {
 		return subBravia;
 	}
-	
+
 	public boolean clearCookies() {
 		return clearCookies;
 	}
-	
+
 	////////////////////////////////////////
 	// Misc. methods
 	////////////////////////////////////////
-	
+
 	public String scriptFile(String file) {
 		return scriptPath+File.separator+file;
 	}
-	
+
 	//////////////////////////////////////
 	// Other methods
 	//////////////////////////////////////
-	
+
 	public void init() {
 		// Paths
 		chPath=Channels.getPath();
@@ -392,7 +392,7 @@ public class ChannelCfg {
 		cookiePath=(String) PMS.getConfiguration().getCustomProperty("cookie.path");
 		credPath=(String) PMS.getConfiguration().getCustomProperty("cred.path");
 		chZipUrl=(String) PMS.getConfiguration().getCustomProperty("channels.ch_zip");
-		
+
 		// Other
 		String dbg=(String)PMS.getConfiguration().getCustomProperty("channels.debug");
 		String sub=(String) PMS.getConfiguration().getCustomProperty("channels.subtitles");
@@ -421,10 +421,10 @@ public class ChannelCfg {
 		String bu=(String)PMS.getConfiguration().getCustomProperty("channels.bad_url");
 		String bs=(String)PMS.getConfiguration().getCustomProperty("channels.bravia_sub");
 		String cc=(String)PMS.getConfiguration().getCustomProperty("channels.clear_cookies");
-		
+
 		if(!ChannelUtil.empty(cf))
 			crawlFormat=cf;
-		
+
 		if(rtmpMode!=null) {
 			if(rtmpMode.trim().equalsIgnoreCase("1"))
 				Channels.rtmpMethod(Channels.RTMP_MAGIC_TOKEN);
@@ -446,11 +446,11 @@ public class ChannelCfg {
 				Channels.setCache(true);
 			else
 				Channels.setCache(false);
-		
+
 		// Defaults
 		if(ChannelUtil.empty(rtmpPath)) {
 			File plugPath=new File(PMS.getConfiguration().getMplayerPath());
-			String ext=(PMS.get().isWindows()?".exe":"");
+			String ext=(Platform.isWindows()?".exe":"");
 			File f=new File(plugPath.getParent()+File.separator+"rtmpdump"+ext);
 			if(f.exists()&&f.canExecute())
 				rtmpPath=f.getAbsolutePath();
@@ -543,7 +543,7 @@ public class ChannelCfg {
 		if(!ChannelUtil.empty(val))
 			PMS.getConfiguration().setCustomProperty(key,val);
 	}
-	
+
 	public void commit() {
 		top.setSave(saPath);
 		top.setPath(chPath);
@@ -576,52 +576,52 @@ public class ChannelCfg {
 		//	PMS.getConfiguration().setCustomProperty("channels.mpeg2_force",String.valueOf(mp2force));
 			PMS.getConfiguration().setCustomProperty("channels.pmsencoder", String.valueOf(pmsenc));
 			PMS.getConfiguration().setCustomProperty("channels.stream_var", String.valueOf(streamVar));
-			if(!ChannelUtil.empty(navixUploadList)) 
+			if(!ChannelUtil.empty(navixUploadList))
 				PMS.getConfiguration().setCustomProperty("channels.navix_upload",
 						ChannelUtil.append(navixUploadList,",",navixUploadList2));
 			PMS.getConfiguration().save();
 		} catch (Exception e) {
 		}
 	}
-	
+
 	public void ensureCreated(String p) {
 		File f=new File(p);
 		if(!(f.exists()&&f.isDirectory()))
 			f.mkdir();
 	}
-	
+
 	private void validatePMSEncoder() throws IOException {
 		if(pmsenc)
 			setEngines();
-		if(ChannelUtil.empty(scriptPath)) { 
+		if(ChannelUtil.empty(scriptPath)) {
 			ensureCreated("scripts");
 			scriptPath=new File("scripts").getCanonicalPath().toString();
 		}
 		else
 			ensureCreated(scriptPath);
 	}
-	
+
 	private void setEngines() {
 		List<String> eng=PMS.getConfiguration().getEnginesAsList(PMS.get().getRegistry());
 		for(int i=0;i<eng.size();i++) {
-			if(eng.get(i).equalsIgnoreCase("pmsencoder")) // pmsencoder is there  
+			if(eng.get(i).equalsIgnoreCase("pmsencoder")) // pmsencoder is there
 				return;
 		}
 		eng.add("pmsencoder");
-		PMS.getConfiguration().setEnginesAsList((ArrayList<String>) eng);		
+		PMS.getConfiguration().setEnginesAsList((ArrayList<String>) eng);
 	}
-	
+
 	////////////////////////////////////////////
 	// Fetch files
 	///////////////////////////////////////////
-	
+
 	private static final String chList="https://github.com/SharkHunter/Channel/tree/master/channels";
 	private static final String scList="https://github.com/SharkHunter/Channel/tree/master/scripts";
 	private static final String chReg="<td class=\"content\">\\s*.*?<a href=\"[^\"]+\" [^>]+>([^<]+)</a>";
 	private static final String rawChBase="https://github.com/SharkHunter/Channel/raw/master/channels/";
 	private static final String rawScBase="https://github.com/SharkHunter/Channel/raw/master/scripts/";
-	private static final String pywin="http://sharkhunter-shb.googlecode.com/files/pywin.zip"; 
-	
+	private static final String pywin="http://sharkhunter-shb.googlecode.com/files/pywin.zip";
+
 	private void fetchFromGit(String list,String raw,String path) throws Exception {
 		URL u=new URL(list);
 		Pattern re=Pattern.compile(chReg);
@@ -649,8 +649,8 @@ public class ChannelCfg {
             dest.close();
             in.close();
 		}
-      } 
-	
+      }
+
 	private void fetchPyWinOverlay() throws ConfigurationException {
 		String tmp = (String) PMS.getConfiguration().getCustomProperty("python.pywin_extra");
 		if(ChannelUtil.empty(tmp)||!tmp.equalsIgnoreCase("true")) {
@@ -666,7 +666,7 @@ public class ChannelCfg {
 	}
 
 	public void fetchChannels() {
-		try {			
+		try {
 			validatePMSEncoder();
 			// fetch channels
 			fetchFromGit(chList,rawChBase,chPath);
@@ -677,13 +677,13 @@ public class ChannelCfg {
 		}
 		catch(Exception e) {
 			Channels.debug("error fetching channels "+e);
-		}	
+		}
 	}
-	
+
 	///////////////////////////////////////////////////
 	// Channel Var functions
 	///////////////////////////////////////////////////
-	
+
 	public void putChVars(String ch,String inst,String var,String val) {
 		String vData=ChannelUtil.append(ch, "@", inst);
 		String putData=vData+"@"+var+"@"+val;
@@ -702,7 +702,7 @@ public class ChannelCfg {
 			}
 			if(!found) // new variable
 				pData=putData+","+pData;
-			putData=pData;		
+			putData=pData;
 		}
 		try {
 			PMS.getConfiguration().setCustomProperty("channels.ch_vars", putData);
@@ -710,7 +710,7 @@ public class ChannelCfg {
 		} catch (ConfigurationException e) {
 		}
 	}
-	
+
 	public void chVars(String chName,Channel ch) {
 		if(stdAlone)
 			return;

--- a/src/com/sharkhunter/channel/ChannelCrawl.java
+++ b/src/com/sharkhunter/channel/ChannelCrawl.java
@@ -5,31 +5,30 @@ import java.util.Collections;
 import java.util.Comparator;
 
 import net.pms.dlna.DLNAResource;
-import net.pms.dlna.virtual.VirtualVideoAction;
 
 public class ChannelCrawl implements Comparator {
-	
+
 	public final static int CRAWL_FLA = 0;
 	public final static int CRAWL_HML = 1;
-	
+
 	public final static int CRAWL_HIGH = 0;
 	public final static int CRAWL_MED = 1;
 	public final static int CRAWL_LOW = 2;
 	public final static int CRAWL_FIRST = 3;
 	public final static int CRAWL_LAST = 4;
 	public final static int CRAWL_ALL = 5;
-	
+
 	public final static int CRAWL_UNKNOWN = -1;
-	
+
 	private final static int MAX_LOOP = 20;
-	
+
 	private boolean allMode;
 	private String name;
-	
+
 	///////////////////////////////////////////////////
 	// Static parse functions
 	//////////////////////////////////////////////////
-	
+
 	private static int parseFLA(String str) {
 		if(str.equalsIgnoreCase("first"))
 			return ChannelCrawl.CRAWL_FIRST;
@@ -39,7 +38,7 @@ public class ChannelCrawl implements Comparator {
 			return ChannelCrawl.CRAWL_LAST;
 		return ChannelCrawl.CRAWL_FIRST;
 	}
-	
+
 	private static int parseHML(String str) {
 		if(str.equalsIgnoreCase("high"))
 			return ChannelCrawl.CRAWL_HIGH;
@@ -49,7 +48,7 @@ public class ChannelCrawl implements Comparator {
 			return ChannelCrawl.CRAWL_LOW;
 		return CRAWL_HIGH;
 	}
-	
+
 	public static int parseCrawlMode(int mainMode,String str) {
 		if(mainMode==CRAWL_FLA)
 			return parseFLA(str);
@@ -57,30 +56,30 @@ public class ChannelCrawl implements Comparator {
 			return parseHML(str);
 		return CRAWL_UNKNOWN;
 	}
-	
+
 	////////////////////////////////////////////////////////////////
 	// Rest of class
 	////////////////////////////////////////////////////////////////
-	
+
 	public ChannelCrawl() {
 		allMode=false;
 		name=null;
 	}
-	
+
 	public boolean allSeen() {
 		return allMode;
 	}
-	
+
 	public String goodName() {
 		return name;
 	}
-	
+
 	public static DLNAResource crawlOneLevel(ArrayList<DLNAResource> start,int crawlMode) {
 		int pos=-1;
 		int size=start.size();
 		if(size==0)
 			return null;
-		
+
 		switch(crawlMode) {
 		case CRAWL_LOW:
 		case CRAWL_FIRST:
@@ -96,7 +95,7 @@ public class ChannelCrawl implements Comparator {
 		default:
 			break;
 		}
-		
+
 		while(pos > -1) {
 			DLNAResource tmp=start.get(pos);
 			if(ChannelUtil.filterInternals(tmp)){
@@ -111,7 +110,7 @@ public class ChannelCrawl implements Comparator {
 		}
 		return null;
 	}
-	
+
 	public DLNAResource crawlOne(ArrayList<DLNAResource> start,int crawlMode) {
 		switch(crawlMode) {
 		case CRAWL_ALL:
@@ -122,7 +121,7 @@ public class ChannelCrawl implements Comparator {
 		}
 		return crawlOneLevel(start,crawlMode);
 	}
-	
+
 	private ArrayList<DLNAResource> sortedList(ArrayList<DLNAResource> list) {
 		ArrayList<DLNAResource> res=new ArrayList<DLNAResource>();
 		for(DLNAResource r : list) {
@@ -134,13 +133,13 @@ public class ChannelCrawl implements Comparator {
 		Collections.sort(res, this);
 		return res;
 	}
-	
+
 	public DLNAResource crawl(ArrayList<DLNAResource> start,int[] modes) {
 		ArrayList<DLNAResource> res=start;
 		DLNAResource res1=null;
 		for(int i=0;i<modes.length;i++) {
 			int crawlMode=-1;
-			if(modes[i]==CRAWL_FLA) 
+			if(modes[i]==CRAWL_FLA)
 				crawlMode=Channels.cfg().getCrawlFLMode();
 			if(modes[i]==CRAWL_HML) {
 				crawlMode=Channels.cfg().getCrawlHLMode();
@@ -155,17 +154,17 @@ public class ChannelCrawl implements Comparator {
 			res=(ArrayList<DLNAResource>) res1.getChildren();
 		}
 		if(res1 instanceof ChannelPMSSaveFolder) {
-			// Compensate for the save folder, We know the last one 
+			// Compensate for the save folder, We know the last one
 			// in the save folder is the PLAY option so we use that one
 			res1=crawlOneLevel((ArrayList<DLNAResource>) res1.getChildren(),CRAWL_LAST);
 		}
 		return res1;
 	}
-	
+
 	public DLNAResource crawl(DLNAResource start,int[] modes) {
 		return crawl((ArrayList<DLNAResource>) start.getChildren(),modes);
 	}
-	
+
 	private int[] mkModes(String modeStr) {
 		String[] tmp=modeStr.split("\\+");
 		int[] modes=new int[tmp.length];
@@ -179,7 +178,7 @@ public class ChannelCrawl implements Comparator {
 		}
 		return modes;
 	}
-	
+
 	private String findMode(DLNAResource r) {
 		if(r instanceof ChannelPMSFolder) {
 			ChannelPMSFolder pmf=(ChannelPMSFolder)r;
@@ -190,7 +189,7 @@ public class ChannelCrawl implements Comparator {
 		}
 		return "FLA";
 	}
-	
+
 	public DLNAResource startCrawl(ArrayList<DLNAResource> start,String modeStr) {
 		Channels.debug("do crawl for "+start+ " mode "+modeStr);
 		DLNAResource r=crawl(start, mkModes(modeStr));
@@ -200,7 +199,7 @@ public class ChannelCrawl implements Comparator {
 		for(int i=0;i<MAX_LOOP;i++) {
 			if(r==null) // nothing found?
 				return null;
-			if(r instanceof ChannelMediaStream) { 
+			if(r instanceof ChannelMediaStream) {
 				// terminal crawl case, we're done here
 				return r;
 			}
@@ -215,7 +214,7 @@ public class ChannelCrawl implements Comparator {
 		// if we get here return what we got
 		return r;
 	}
-	
+
 	public DLNAResource startCrawl(DLNAResource start,String modeStr) {
 		if(ChannelUtil.empty(modeStr)) {
 			modeStr=findMode(start);
@@ -234,50 +233,50 @@ public class ChannelCrawl implements Comparator {
         if (s2 == null || s1 == null) {
             return 0;
         }
- 
+
         int lengthFirstStr = s1.length();
         int lengthSecondStr = s2.length();
- 
+
         int index1 = 0;
         int index2 = 0;
- 
+
         while (index1 < lengthFirstStr && index2 < lengthSecondStr) {
             char ch1 = s1.charAt(index1);
             char ch2 = s2.charAt(index2);
- 
+
             char[] space1 = new char[lengthFirstStr];
             char[] space2 = new char[lengthSecondStr];
- 
+
             int loc1 = 0;
             int loc2 = 0;
- 
+
             do {
                 space1[loc1++] = ch1;
                 index1++;
- 
+
                 if (index1 < lengthFirstStr) {
                     ch1 = s1.charAt(index1);
                 } else {
                     break;
                 }
             } while (Character.isDigit(ch1) == Character.isDigit(space1[0]));
- 
+
             do {
                 space2[loc2++] = ch2;
                 index2++;
- 
+
                 if (index2 < lengthSecondStr) {
                     ch2 = s2.charAt(index2);
                 } else {
                     break;
                 }
             } while (Character.isDigit(ch2) == Character.isDigit(space2[0]));
- 
+
             String str1 = new String(space1);
             String str2 = new String(space2);
- 
+
             int result;
- 
+
             if (Character.isDigit(space1[0]) && Character.isDigit(space2[0])) {
                 Integer firstNumberToCompare = new Integer(Integer
                         .parseInt(str1.trim()));
@@ -287,7 +286,7 @@ public class ChannelCrawl implements Comparator {
             } else {
                 result = str1.compareTo(str2);
             }
- 
+
             if (result != 0) {
                 return result;
             }

--- a/src/com/sharkhunter/channel/ChannelDbg.java
+++ b/src/com/sharkhunter/channel/ChannelDbg.java
@@ -7,25 +7,25 @@ import java.io.IOException;
 import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
-
 import org.apache.commons.configuration.ConfigurationException;
-
+import org.slf4j.LoggerFactory;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 
 public class ChannelDbg {
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ChannelDbg.class);
 	private BufferedWriter os;
 	private File f;
 	private SimpleDateFormat sdfHour;
 	private SimpleDateFormat sdfDate;
-	
+
 	public ChannelDbg(File f) {
 		this.f=f;
 		os=null;
 		sdfHour = new SimpleDateFormat("HH:mm:ss.SSS", Locale.US); //$NON-NLS-1$
         sdfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US); //$NON-NLS-1$
 	}
-	
+
 	private void ensureDbgPack() throws ConfigurationException {
 		PmsConfiguration conf=PMS.getConfiguration();
 		if(conf==null)
@@ -42,7 +42,7 @@ public class ChannelDbg {
 		conf.setCustomProperty("dbgpack", str);
 		conf.save();
 	}
-	
+
 	public void start() {
 		if(os!=null)
 			return;
@@ -57,7 +57,7 @@ public class ChannelDbg {
 			os=null;
 		}
 	}
-	
+
 	public void stop() {
 		if(os!=null) {
 			try {
@@ -65,19 +65,19 @@ public class ChannelDbg {
 				os.close();
 				debug("Stopped");
 			}
-			catch (IOException e) {}			
+			catch (IOException e) {}
 			os=null;
 		}
 	}
-	
+
 	public boolean status() {
 		return (os!=null);
 	}
-	
+
 	public File logFile() {
 		return f;
 	}
-	
+
 	public void debug(String str) {
 		if(os==null)
 			return;
@@ -86,7 +86,7 @@ public class ChannelDbg {
 			os.write("\n\r"+s+"\n\r");
 			os.flush();
 		} catch (IOException e) {
-			PMS.debug("[Channel]: "+str);
+			LOGGER.debug("{Channel} {}", str);
 		}
 	}
 }

--- a/src/com/sharkhunter/channel/ChannelGUI.java
+++ b/src/com/sharkhunter/channel/ChannelGUI.java
@@ -9,8 +9,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -18,18 +16,13 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
 import javax.swing.JTextField;
-import javax.swing.Popup;
-import javax.swing.table.DefaultTableModel;
-
-import net.pms.PMS;
+import org.slf4j.LoggerFactory;
 
 public class ChannelGUI implements  ActionListener, ItemListener{
-	
+
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ChannelGUI.class);
 	private ChannelCfg cfg;
 	private Channels root;
 	private JTextField chPath;
@@ -48,12 +41,12 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 	private JCheckBox subs;
 	private JCheckBox favorite;
 	private JComponent topComp;
-	
+
 	public ChannelGUI(ChannelCfg cfg,Channels root) {
 		this.cfg=cfg;
 		this.root=root;
 	}
-	
+
 	public JComponent draw() {
 		JPanel top=new JPanel(new BorderLayout(10,10));
 		JPanel top1=new JPanel(new BorderLayout(10,10));
@@ -132,7 +125,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		favorite.addItemListener(this);
 		commit.setActionCommand("other_commit");
 		commit.addActionListener(this);
-		
+
 		GridBagConstraints c = new GridBagConstraints();
 		// 1st the channels path
 		c.fill = GridBagConstraints.BOTH;
@@ -158,7 +151,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		c.gridx++;
 		c.weightx=1.0;
 		pathPanel.add(sBrowse,c);
-		
+
 		// 3rd the cred path
 		c.gridx = 0;
 		c.gridy = 2;
@@ -170,7 +163,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		c.gridx++;
 		c.weightx=1.0;
 		pathPanel.add(credBrowse,c);
-		
+
 		// NaviXList
 		c.gridx = 0;
 		c.gridy = 3;
@@ -179,7 +172,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		c.gridx++;
 		c.weightx=2.0;
 		pathPanel.add(naviText,c);
-		
+
 		// Debug
 		c.gridx = 0;
 		c.gridy = 4;
@@ -195,7 +188,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		c.gridy = 6;
 		c.weightx=1.0;
 		pathPanel.add(favorite,c);
-		
+
 		// Sopcast
 		c.gridx = 0;
 		c.gridy = 1;
@@ -207,7 +200,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		c.gridx++;
 		c.weightx=1.0;
 		pmsenc.add(sopBrowse,c);
-		
+
 		// PPLive
 		c.gridx = 0;
 		c.gridy = 2;
@@ -219,7 +212,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		c.gridx++;
 		c.weightx=1.0;
 		pmsenc.add(ppBrowse,c);
-		
+
 		// Add installation buttons
 		// Channels
 		c.fill = GridBagConstraints.BOTH;
@@ -236,7 +229,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		topComp=top;
 		return top;
 	}
-	
+
 	private JFrame cw;
 
 	@Override
@@ -275,7 +268,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 						else if(text.equals("navix")) {
 							String t=naviText.getText();
 							if(!ChannelUtil.empty(t)&&!t.equals(cfg.getNaviXUpload()))
-								cfg.setNaviXUpload(t);	
+								cfg.setNaviXUpload(t);
 						}
 						update();
 						cfg.commit();
@@ -286,7 +279,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		}
 		else  {
 			if(text.equals("other_commit")||text.equals("other_channels")) {
-				PMS.debug("update channels files");
+				LOGGER.debug("{Channel} Update channels files");
 				pushPaths();
 				cfg.commit();
 				if(text.equals("other_channels")) {
@@ -302,7 +295,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 	public void itemStateChanged(ItemEvent e) {
 		boolean val=true;
 		Object source = e.getItemSelectable();
-		if (e.getStateChange() == ItemEvent.DESELECTED) 
+		if (e.getStateChange() == ItemEvent.DESELECTED)
 			val=false;
 		if(source==dbg)
 			Channels.debug(val);
@@ -312,7 +305,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 			cfg.setFavorite(val);
 		cfg.commit();
 	}
-	
+
 	private void update() {
 		chPath.setText(cfg.getPath());
 		saPath.setText(cfg.getSavePath());
@@ -326,7 +319,7 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 		yt.setText(cfg.getYouTubePath());
 		credText.setText(cfg.getCredPath());
 	}
-	
+
 	private void pushPaths() {
 		cfg.setPath(chPath.getText());
 		cfg.setRtmpPath(rtmp.getText());
@@ -345,5 +338,5 @@ public class ChannelGUI implements  ActionListener, ItemListener{
 			Channels.initNaviX();
 		}
 	}
-	
+
 }

--- a/src/com/sharkhunter/channel/ChannelISO.java
+++ b/src/com/sharkhunter/channel/ChannelISO.java
@@ -2,7 +2,6 @@ package com.sharkhunter.channel;
 
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.Set;
 
 public class ChannelISO {
 	private static HashMap<String,String> special=new HashMap<String,String>();
@@ -36,16 +35,16 @@ public class ChannelISO {
 			special.put(iso3, iso2);
 		}
 	}
-	
+
 	public static String iso(String someIso,int wantedIso) {
-		if(someIso.length()==wantedIso) 
+		if(someIso.length()==wantedIso)
 			return someIso;
 		return special.get(someIso);
 	}
-	
+
 	public static boolean equal(String a,String b) {
 		return a.equals(iso(b,a.length()));
 	}
-	
-	
+
+
 }

--- a/src/com/sharkhunter/channel/ChannelImageStream.java
+++ b/src/com/sharkhunter/channel/ChannelImageStream.java
@@ -1,15 +1,8 @@
 package com.sharkhunter.channel;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.URLEncoder;
-
-import net.pms.PMS;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAResource;
 import net.pms.formats.Format;
@@ -19,7 +12,7 @@ public class ChannelImageStream extends DLNAResource{
 	private String url;
 	private String thumb;
 	private String auth;
-	
+
 	public ChannelImageStream(String name,String url,String thumb,String auth) {
 		super(Format.IMAGE);
 		this.name=name;
@@ -27,39 +20,39 @@ public class ChannelImageStream extends DLNAResource{
 		this.thumb=thumb;
 		this.auth=auth;
 	}
-	
+
 	public String getName() {
 		return name;
 	}
-	
+
 	public String getSystemName() {
 		return url;
 	}
-	
+
 	public boolean isUnderlyingSeekSupported() {
 		return true;
 	}
-	
+
 	@Override
 	public void resolve() {
 	}
-	
+
 	@Override
 	public boolean isValid() {
-		checktype();
+		resolveFormat();
 		return true;
-		
+
 	}
-	
+
 	@Override
 	public long length() {
 		return DLNAMediaInfo.TRANS_SIZE;
     }
-	
+
 	public boolean isFolder() {
         return false;
 	}
-	
+
 	public InputStream getInputStream() {
 		try {
 			URL urlobj = new URL(url);
@@ -67,7 +60,7 @@ public class ChannelImageStream extends DLNAResource{
 			//ByteArrayOutputStream bytes = new ByteArrayOutputStream();
 			URLConnection conn = urlobj.openConnection();
 			conn.setRequestProperty("User-Agent","Mozilla/5.0 (Windows; U; Windows NT 6.1; sv-SE; rv:1.9.2.3) Gecko/20100409 Firefox/3.6.3");
-			if(!ChannelUtil.empty(auth))	
+			if(!ChannelUtil.empty(auth))
 				conn.setRequestProperty("Authorization", auth);
 			InputStream in = conn.getInputStream();
 			return in;

--- a/src/com/sharkhunter/channel/ChannelItem.java
+++ b/src/com/sharkhunter/channel/ChannelItem.java
@@ -4,27 +4,27 @@ import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.util.ArrayList;
-
-import net.pms.PMS;
+import org.slf4j.LoggerFactory;
 import net.pms.dlna.DLNAResource;
 
 public class ChannelItem implements ChannelProps{
-	
+
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ChannelItem.class);
 	public boolean Ok;
-	
+
 	private Channel parent;
 	private ChannelFolder parentFolder;
-	
+
 	private ChannelMatcher matcher;
-	
+
 	private String url;
 	private String name;
 	private String[] prop;
-	
+
 	private String thumbURL;
-	
+
 	private ArrayList<ChannelMedia> mediaURL;
-	
+
 	public ChannelItem(ArrayList<String> data,Channel parent,ChannelFolder pf) {
 		Ok=false;
 		this.parent=parent;
@@ -35,7 +35,7 @@ public class ChannelItem implements ChannelProps{
 		parse(data);
 		Ok=true;
 	}
-	
+
 	public void parse(ArrayList<String> data) {
 		for(int i=0;i<data.size();i++) {
 			String line=data.get(i).trim();
@@ -55,13 +55,13 @@ public class ChannelItem implements ChannelProps{
 				if(m!=null)
 					parse(m.getMacro());
 				else
-					PMS.debug("unknown macro "+keyval[1]);
-			}	
+					LOGGER.debug("{Channel} Unknown macro {}", keyval[1]);
+			}
 			if(keyval[0].equalsIgnoreCase("name"))
 				name=keyval[1];
-			if(keyval[0].equalsIgnoreCase("url"))	
+			if(keyval[0].equalsIgnoreCase("url"))
 				url=keyval[1];
-			if(keyval[0].equalsIgnoreCase("prop"))	
+			if(keyval[0].equalsIgnoreCase("prop"))
 				prop=keyval[1].trim().split(",");
 			if(keyval[0].equalsIgnoreCase("matcher")) {
 				if(matcher==null)
@@ -81,19 +81,19 @@ public class ChannelItem implements ChannelProps{
 		if(matcher!=null)
 			matcher.processProps(prop);
 	}
-	
+
 	public boolean autoMedia() {
 		return ChannelUtil.getProperty(prop, "auto_media");
 	}
-	
+
 	public ChannelMatcher getMatcher() {
 		return matcher;
 	}
-	
+
 	public void match(DLNAResource res) throws MalformedURLException {
 		match(res,"","","",null);
 	}
-	
+
 	public void match(DLNAResource res,String filter,String urlEnd,String backupName,
 			String pThumb) throws MalformedURLException {
 		String u=ChannelUtil.concatURL(url,urlEnd);
@@ -142,22 +142,22 @@ public class ChannelItem implements ChannelProps{
 	    	}
 	    }
 	}
-	
+
 	public String separator(String base) {
 		return ChannelUtil.getPropertyValue(prop, base+"_separator");
 	}
-	
+
 	public boolean onlyFirst() {
 		return ChannelUtil.getProperty(prop, "only_first");
 	}
-	
+
 	public String append(String base) {
 		return ChannelUtil.getPropertyValue(prop,"append_"+base);
 	}
 	public String prepend(String base) {
 		return ChannelUtil.getPropertyValue(prop,"prepend_"+base);
 	}
-	
+
 	public String rawEntry() {
 		StringBuilder sb=new StringBuilder();
 		sb.append("item {");
@@ -192,11 +192,11 @@ public class ChannelItem implements ChannelProps{
 		sb.append("\n}\n");
 		return sb.toString();
 	}
-	
+
 	public String getProp(String p) {
 		return ChannelUtil.getPropertyValue(prop, p);
 	}
-	
+
 	@Override
 	public boolean escape(String base) {
 		return ChannelUtil.getProperty(prop, base+"_escape");
@@ -207,7 +207,7 @@ public class ChannelItem implements ChannelProps{
 	public boolean unescape(String base) {
 		return ChannelUtil.getProperty(prop, base+"_unescape");
 	}
-	
+
 	public String mangle(String base) {
 		return ChannelUtil.getPropertyValue(prop, base+"_mangle");
 	}

--- a/src/com/sharkhunter/channel/ChannelLogin.java
+++ b/src/com/sharkhunter/channel/ChannelLogin.java
@@ -8,19 +8,15 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.TimeZone;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
 
-import com.sun.net.ssl.HostnameVerifier;
 import com.sun.syndication.io.impl.Base64;
 
-import net.pms.PMS;
-
 public class ChannelLogin {
-	
+
 	public static final int STD=0;
 	public static final int COOKIE=1;
 	public static final int APIKEY=2;
@@ -44,7 +40,7 @@ public class ChannelLogin {
 	private ChannelSimple pre_fetch;
 	private boolean preFetched;
 	private String activeParams;
-	
+
 	public ChannelLogin(ArrayList<String> data,Channel parent) {
 		this.parent=parent;
 		this.loggedOn=false;
@@ -58,7 +54,7 @@ public class ChannelLogin {
 		activeParams="";
 		parse(data);
 	}
-	
+
 	public void parse(ArrayList<String> data) {
 		for(int i=0;i<data.size();i++) {
 			String line=data.get(i).trim();
@@ -111,13 +107,13 @@ public class ChannelLogin {
 			}
 		}
 	}
-	
+
 	private String mkQueryString(String usr,String pass) {
 		String usr_pwd=user+"="+ChannelUtil.escape(usr)+
 		"&"+pwd+"="+ChannelUtil.escape(pass);
 		return ChannelUtil.append(activeParams, "&", usr_pwd);
 	}
-	
+
 	private ChannelAuth mkResult(ChannelAuth a) {
 		if(a==null)
 			a=new ChannelAuth();
@@ -126,7 +122,7 @@ public class ChannelLogin {
 		a.ttd=ttd;
 		return a;
 	}
-	
+
 	private ChannelAuth stdLogin(String usr,String pass,ChannelAuth a) throws Exception {
 		String query=mkQueryString(usr,pass);
 		//Channels.debug("url "+url+" query "+query);
@@ -136,14 +132,14 @@ public class ChannelLogin {
 			connection = (HttpsURLConnection) u.openConnection();
 			HttpsURLConnection.setFollowRedirects(true);
 			 HttpsURLConnection.setDefaultHostnameVerifier(new NullHostnameVerifier());
-			((HttpURLConnection) connection).setInstanceFollowRedirects(true);   
+			((HttpURLConnection) connection).setInstanceFollowRedirects(true);
 			((HttpURLConnection) connection).setRequestMethod("POST");
 		}
 		else {
 			connection = (HttpURLConnection) u.openConnection();
 			HttpURLConnection.setFollowRedirects(true);
-			((HttpURLConnection) connection).setInstanceFollowRedirects(true);   
-			((HttpURLConnection) connection).setRequestMethod("POST");  
+			((HttpURLConnection) connection).setInstanceFollowRedirects(true);
+			((HttpURLConnection) connection).setRequestMethod("POST");
 		}
 		String page=ChannelUtil.postPage(connection, query);
 		//PMS.debug("got page after post "+page);
@@ -159,7 +155,7 @@ public class ChannelLogin {
 		}
 		return null;
 	}
-	
+
 	private ChannelAuth updateCookieDb(String cookie,ChannelAuth a) {
 		String u=ChannelUtil.trimURL(url);
 		Channels.debug("update cookie db "+u);
@@ -175,7 +171,7 @@ public class ChannelLogin {
 			Channels.mkCookieFile();
 		return a;
 	}
-	
+
 	private long parseTTD(String expStr,SimpleDateFormat sdfDate) throws ParseException {
 		java.util.Date d;
 		String[] tmp=expStr.trim().split(" ");
@@ -194,9 +190,9 @@ public class ChannelLogin {
 		c.setTime(d);
 		c.setTimeZone(TimeZone.getDefault());
 		c.get(Calendar.DATE);
-		return c.getTimeInMillis();		
+		return c.getTimeInMillis();
 	}
-	
+
 	private long parseTTD(String expStr) {
 		SimpleDateFormat sdfDate = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss");
 		SimpleDateFormat sdfDate1 = new SimpleDateFormat("dd-MMM-yyyy HH:mm:ss z");
@@ -211,14 +207,14 @@ public class ChannelLogin {
 		}
 		return ttd;
 	}
-	
-	
+
+
 	private ChannelAuth getCookie(URLConnection connection,ChannelAuth a) throws Exception {
 		String hName="";
 		for (int j=1; (hName = connection.getHeaderFieldKey(j))!=null; j++) {
 		 	String cStr=connection.getHeaderField(j);
 			Channels.debug("hdr "+hName);
-		 	if (!hName.equalsIgnoreCase("Set-Cookie")) 
+		 	if (!hName.equalsIgnoreCase("Set-Cookie"))
 		 		continue;
 		 	String[] fields = cStr.split(";\\s*");
 	 		String cookie=fields[0];
@@ -250,7 +246,7 @@ public class ChannelLogin {
 	        return mkResult(a);
 		return null;
 	}
-	
+
 	private ChannelAuth cookieLogin(String usr,String pass,ChannelAuth a) throws Exception {
 		ChannelAuth a1=Channels.getCookie(ChannelUtil.trimURL(url));
 		if(a1!=null) { // found some in hash
@@ -281,7 +277,7 @@ public class ChannelLogin {
 			HttpsURLConnection connection = (HttpsURLConnection) u.openConnection(p);
 			 HttpsURLConnection.setFollowRedirects(true);
 			 HttpsURLConnection.setDefaultHostnameVerifier(new NullHostnameVerifier());
-			((HttpsURLConnection) connection).setInstanceFollowRedirects(true);   
+			((HttpsURLConnection) connection).setInstanceFollowRedirects(true);
 			((HttpsURLConnection) connection).setRequestMethod(method);
 			String page=ChannelUtil.postPage(connection, query);
 			//Channels.debug("login res page "+page);
@@ -291,8 +287,8 @@ public class ChannelLogin {
 		}
 		else {
 			HttpURLConnection connection = (HttpURLConnection) u.openConnection();
-			HttpURLConnection.setFollowRedirects(true);   
-			connection.setInstanceFollowRedirects(true);   
+			HttpURLConnection.setFollowRedirects(true);
+			connection.setInstanceFollowRedirects(true);
 			connection.setRequestMethod(method);
 			String page=ChannelUtil.postPage(connection, query);
 			//Channels.debug("login page "+page);
@@ -301,7 +297,7 @@ public class ChannelLogin {
 			return getCookie(connection,a);
 		}
 	}
-	
+
 	private ChannelAuth basicLogin(String usr,String pass,ChannelAuth a) {
 		String tmp=usr+":"+pass;
 		tokenStr=Base64.encode(tmp);
@@ -309,11 +305,11 @@ public class ChannelLogin {
 		type=ChannelLogin.STD;
 		return mkResult(a);
 	}
-	
+
 	public ChannelAuth getAuthStr(String usr,String pass,ChannelAuth a) {
 		return getAuthStr(usr,pass,false,a);
 	}
-	
+
 	public ChannelAuth getAuthStr(String usr,String pass,boolean media,ChannelAuth a) {
 		Channels.debug("login on channel "+parent.getName()+" type "+type+" on "+loggedOn);
 		/*Date d=new Date(ttd);
@@ -368,13 +364,13 @@ public class ChannelLogin {
 			return a;
 		}
 	}
-	
+
 	public void reset() {
 		tokenStr="";
 		loggedOn=false;
 		ttd=0;
 	}
-	
+
 	private static class NullHostnameVerifier implements javax.net.ssl.HostnameVerifier {
 	    public boolean verify(String hostname, SSLSession session) {
 	        return true;

--- a/src/com/sharkhunter/channel/ChannelMonitor.java
+++ b/src/com/sharkhunter/channel/ChannelMonitor.java
@@ -6,10 +6,9 @@ import java.util.HashMap;
 
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.virtual.VirtualFolder;
-import net.pms.dlna.virtual.VirtualVideoAction;
 
 public class ChannelMonitor {
-	
+
 	private ChannelFolder cf;
 	private ArrayList<String> oldEntries;
 	private String name;
@@ -27,17 +26,17 @@ public class ChannelMonitor {
 		scanning=false;
 		try_search = false;
 	}
-	
+
 	public void setTemplate(String t) {
 		templ=t;
 	}
-	
+
 	public void setSearch(String s) {
 		search=s;
 	}
 
 	public void setTrySearch(boolean b) { try_search = b; }
-	
+
 	public void scan() {
 		if(scanning)
 			return;
@@ -62,7 +61,7 @@ public class ChannelMonitor {
 		for(DLNAResource r : dummy.getChildren()) {
 			if(ChannelUtil.empty(templ)) {
 				// standard simple matching
-				if(oldEntries.contains(r.getName().trim())) 
+				if(oldEntries.contains(r.getName().trim()))
 					continue;
 			}
 			else {
@@ -76,7 +75,7 @@ public class ChannelMonitor {
 			doCrawl(crawl,getName().trim());
 		scanning=false;
 	}
-	
+
 	private void doCrawl(ArrayList<DLNAResource> res,String folder) {
 		if(res.isEmpty())
 			return;
@@ -99,7 +98,7 @@ public class ChannelMonitor {
 			rescan(folder);
 		cms.donePlaying();
 	}
-	
+
 	private void rescan(String folder) {
 		Channels.clearNewMediaFolder(folder);
 		Runnable r=new Runnable() {
@@ -110,11 +109,11 @@ public class ChannelMonitor {
     	};
     	new Thread(r).start();
 	}
-	
+
 	public String getName() {
 		return name;
 	}
-	
+
 	public boolean addEntry(String newEntry) {
 		Channels.debug("add entry "+newEntry+" old "+oldEntries.contains(newEntry));
 		if(!oldEntries.contains(newEntry)) {
@@ -123,7 +122,7 @@ public class ChannelMonitor {
 		}
 		return false;
 	}
-	
+
 	private boolean templateMatch(String entry) {
 		HashMap<String,String> vars=new HashMap<String,String>();
 		vars.put("entry", entry);
@@ -137,5 +136,5 @@ public class ChannelMonitor {
 		}
 		return res;
 	}
-	
+
 }

--- a/src/com/sharkhunter/channel/ChannelMonitorMgr.java
+++ b/src/com/sharkhunter/channel/ChannelMonitorMgr.java
@@ -7,15 +7,13 @@ import java.util.GregorianCalendar;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import net.pms.dlna.DLNAResource;
-
 public class ChannelMonitorMgr {
-	
+
 	private ArrayList<ChannelMonitor> monitors;
-	
+
 	private static final int PERIOD = 24*60*60*1000;
 	private static final int DEFAULT_DELAY_SCAN = 10*1000;
-	
+
 	public ChannelMonitorMgr() {
 		monitors=new ArrayList<ChannelMonitor>();
 		Timer timer=new Timer();
@@ -31,16 +29,16 @@ public class ChannelMonitorMgr {
 		    	scanAll();
 		    }}, launchTime.getTime(),PERIOD);
 	}
-	
+
 	public void add(ChannelMonitor m) {
 		monitors.add(m);
 	}
-	
+
 	public void scanAll() {
 		for(ChannelMonitor m : monitors)
     		m.scan();
 	}
-	
+
 	public boolean monitored(String name) {
 		for(ChannelMonitor m :monitors) {
 			if(m.getName().equals(name))
@@ -48,7 +46,7 @@ public class ChannelMonitorMgr {
 		}
 		return false;
 	}
-	
+
 	public ChannelMonitor getMonitor(String name) {
 		for(ChannelMonitor m :monitors) {
 			if(name.equals(m.getName()))
@@ -56,18 +54,18 @@ public class ChannelMonitorMgr {
 		}
 		return null;
 	}
-	
+
 	public boolean update(String name,String newEntry) {
 		ChannelMonitor m=getMonitor(name);
 		if(m!=null)
 			return m.addEntry(newEntry);
 		return false;
 	}
-	
+
 	public void delayedScan() {
 		delayedScan(DEFAULT_DELAY_SCAN);
 	}
-	
+
 	public void delayedScan(final int delay) {
 		if(monitors.isEmpty()) // no idea to scan
 			return;

--- a/src/com/sharkhunter/channel/ChannelMovieInfo.java
+++ b/src/com/sharkhunter/channel/ChannelMovieInfo.java
@@ -4,23 +4,23 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
-
-import net.pms.PMS;
+import org.slf4j.LoggerFactory;
 import net.pms.dlna.DLNAResource;
 import net.pms.movieinfo.FileMovieInfoVirtualFolder;
 
 public class ChannelMovieInfo {
 
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ChannelMovieInfo.class);
 	private String plugins;
 	private int numberOfActors;
 	private int lineLength;
-	
+
 	public ChannelMovieInfo() {
 		numberOfActors=0;
 		lineLength=0;
 		parse();
 	}
-	
+
 	public void addFolders(DLNAResource res,String imdbId,String thumb) {
 		if (plugins != null) {
 			String[] plgn = plugins.split(",");
@@ -34,19 +34,19 @@ public class ChannelMovieInfo {
 			}
 		}
 	}
-	
-	private void parse() 
+
+	private void parse()
 	{
-		File miConf = new File("MOVIEINFO.conf"); 
+		File miConf = new File("MOVIEINFO.conf");
 		if (!miConf.exists())
-			miConf = new File("plugins/MOVIEINFO.conf"); 
+			miConf = new File("plugins/MOVIEINFO.conf");
 		if (miConf.exists()) {
 			try {
-				BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(miConf), "UTF-8")); 
+				BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(miConf), "UTF-8"));
 				String line = null;
 				while ((line=br.readLine()) != null) {
 					line = line.trim();
-					if (line.length() > 0 && !line.startsWith("#") && line.indexOf("=") > -1) { 
+					if (line.length() > 0 && !line.startsWith("#") && line.indexOf("=") > -1) {
 						if(line.startsWith("Plugins="))plugins = line.substring(line.indexOf("=")+1,line.length()).toUpperCase();
 						if(line.startsWith("NumberOfActors="))numberOfActors = Integer.parseInt(line.substring(line.indexOf("=")+1,line.length()));
 						if(line.startsWith("Linelength="))lineLength = Integer.parseInt(line.substring(line.indexOf("=")+1,line.length()));
@@ -54,9 +54,9 @@ public class ChannelMovieInfo {
 				}
 				br.close();
 			} catch (Exception e) {
-				e.printStackTrace();
+				LOGGER.debug("{Channel} Exception in parse(): {}", e);
 			}
 		} else
-			PMS.minimal("MOVIEINFO.conf file not found!");
+			LOGGER.info("{Channel} MOVIEINFO.conf file not found!");
 	}
 }

--- a/src/com/sharkhunter/channel/ChannelNaviX.java
+++ b/src/com/sharkhunter/channel/ChannelNaviX.java
@@ -5,11 +5,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.Feed;
@@ -27,7 +25,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 	private String imdbId;
 	private boolean ignoreFav;
 	private boolean ignoreSave;
-	
+
 	public ChannelNaviX(Channel ch,String name,String thumb,String url,
 			String[] props,String[] sub) {
 		super(name,ChannelUtil.getThumb(thumb,null,ch));
@@ -42,24 +40,24 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 		ignoreFav=false;
 		ignoreSave=false;
 	}
-	
+
 	private boolean favFolder() {
 		return !(ignoreFav||parent.noFavorite());
 	}
-	
+
 	public void setIgnoreFav() {
 		ignoreFav=true;
 	}
-	
+
 	public void setIgnoreSave() {
 		ignoreSave=true;
 	}
-	
+
 	private String washName(String name) {
 		name=name.replaceAll("\\[[^]]*\\]","");
 		return name;
 	}
-	
+
 	private void doAdd(DLNAResource upper,DLNAResource res,String name,String url) {
 		if(Channels.isCode(name, ChannelIllegal.TYPE_NAME)||
  		   Channels.isCode(url, ChannelIllegal.TYPE_URL)) {
@@ -70,7 +68,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 		else
 			upper.addChild(res);
 	}
-	
+
 	private void addMedia(String name,String nextUrl,String thumb,String proc,String type,String pp,
 			DLNAResource res,String imdb,Channel ch) {
 		if(type!=null) {
@@ -122,7 +120,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 			else {
 				int f=ChannelUtil.getFormat(type);
 				Channels.debug("add media "+f+" name "+name+" url "+nextUrl);
-				if(f==-1) 
+				if(f==-1)
 					return;
 				int asx;
 				if(ChannelUtil.getProperty(props,"auto_asx"))
@@ -141,7 +139,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 					ChannelMediaStream cms=new ChannelMediaStream(ch,name,nextUrl,thumb,proc,
 							f,asx,this);
 					cms.setImdb(imdb);
-					cms.setRender(this.defaultRenderer);
+					cms.setRender(this.getDefaultRenderer());
 					if(Channels.cfg().useStreamVar()) {
 						ChannelStreamVars streamVars=new ChannelStreamVars(Channels.defStreamVar());
 						streamVars.add(this, parent);
@@ -151,8 +149,8 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 				}
 			}
 		}
-	} 
-	
+	}
+
 	public void readPlx(String str,DLNAResource res) {
 		// The URL found in the cf points to a NaviX playlist
 		// (or similar) fetch and parse
@@ -203,7 +201,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 			else if(line.startsWith("processor="))
 				proc=line.substring(10);
 			else if(line.startsWith("type="))
-				type=line.substring(5);	
+				type=line.substring(5);
 			else if(line.startsWith("playpath="))
 				playpath=line.substring(9);
 			else if(line.startsWith("channel=")) {
@@ -224,7 +222,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 		// add last item
 		addMedia(name,nextUrl,thumb,proc,type,playpath,res,imdb,ch);
 	}
-	
+
 	public void discoverChildren() {
 		if(favFolder()) {
 			// Add bookmark action
@@ -240,7 +238,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 		}
 		readPlx(url,this);
 	}
-	
+
 	public String subCb(String realName) {
 		String imdb=imdbId;
 		imdbId=null; // clear this always
@@ -263,7 +261,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 			Channels.debug("subs "+subFile);
 			if(ChannelUtil.empty(subFile))
 				continue;
-			
+
 			return subFile;
 		}
 		return null;
@@ -279,15 +277,15 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 			return ChannelUtil.badResource();
 		return res;
 	}
-	
+
 	public Channel getChannel() {
 		return parent;
 	}
-	
+
 	public boolean isTranscodeFolderAvailable() {
 		return false;
 	}
-	
+
 	public InputStream getThumbnailInputStream() {
 		try {
 			return downloadAndSend(thumbnailIcon,true);
@@ -296,7 +294,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 			return super.getThumbnailInputStream();
 		}
 	}
-	
+
 	public String rawEntry() {
 		StringBuilder sb=new StringBuilder();
 		sb.append("folder {\n");
@@ -326,7 +324,7 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 		sb.append("\n}\n");
 		return sb.toString();
 	}
-	
+
 	public void bookmark(String name,String url,String thumb) {
 		if(!favFolder()||parent==null) // weird but better safe than sorry
 			return;
@@ -359,15 +357,15 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 	public String backtrackedName(DLNAResource start) {
 		return ChannelSubUtil.backtrackedName(start, props);
 	}
-	
+
 	public ArrayList<String> subSites() {
 		return ChannelSubUtil.subSites(subtitle);
 	}
-	
+
 	public HashMap<String,Object> subSelect(DLNAResource start,String imdb) {
 		return ChannelSubUtil.subSelect(start, imdb, subtitle, parent);
 	}
-	
+
 	public HashMap<String,Object> subSelect(DLNAResource start,String imdb,String subSite) {
 		return ChannelSubUtil.subSelect(start, imdb, subSite, subtitle, parent);
 	}
@@ -384,5 +382,5 @@ public class ChannelNaviX extends VirtualFolder implements ChannelScraper {
 		// TODO Auto-generated method stub
 		return null;
 	}
-	
+
 }

--- a/src/com/sharkhunter/channel/ChannelNaviXUpdate.java
+++ b/src/com/sharkhunter/channel/ChannelNaviXUpdate.java
@@ -1,14 +1,12 @@
 package com.sharkhunter.channel;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ChannelNaviXUpdate {
-	
+
 	private static String baseUrl="http://www.navixtreme.com/";
 	private static String myUrl=baseUrl+"playlist/mine.plx";
 	private static String loginUrl=baseUrl+"members";
@@ -16,7 +14,7 @@ public class ChannelNaviXUpdate {
 	private static String listId=null;
 	private static String naviCookie=null;
 	private static boolean local;
-	
+
 	private static boolean setId(String url,String name,String name1,String type) {
 		Pattern re=Pattern.compile("/(\\d+)/");
 		if(ChannelUtil.empty(url)) {
@@ -49,7 +47,7 @@ public class ChannelNaviXUpdate {
 		}
 		return false;
 	}
-	
+
 	private static void fetchCookie(ChannelCred cr) throws Exception{
 		if(cr==null)
 			return;
@@ -57,7 +55,7 @@ public class ChannelNaviXUpdate {
 		String query="action=takelogin&ajax=1&username="+cr.user+"&password="+cr.pwd;
 		URLConnection c=u.openConnection();
 		String page=ChannelUtil.postPage(c, query);
-		if(ChannelUtil.empty(page)) 
+		if(ChannelUtil.empty(page))
 			throw new Exception("Empty NaviX login page");
 		String[] lines=page.split("\n");
 		if(!lines[0].contains("ok"))
@@ -66,7 +64,7 @@ public class ChannelNaviXUpdate {
 		ChannelCookie.parseCookie(c, a, baseUrl);
 		naviCookie="l_access="+lines[1].trim();
 	}
-	
+
 	private static void fetchListId(String name) throws Exception {
 		Channels.debug("using "+name+" as NaviX upload list");
 		if(name.equals("local")) {
@@ -101,13 +99,13 @@ public class ChannelNaviXUpdate {
 		}
 		setId(url,name,name1,type);
 	}
-	
+
 	public static void init(String listName,ChannelCred cred) throws Exception {
 		local=false;
 		fetchCookie(cred);
-		fetchListId(listName);		
+		fetchListId(listName);
 	}
-	
+
 	private static void upload(String query) throws Exception {
 		if(ChannelUtil.empty(listId)||ChannelUtil.empty(naviCookie))
 			throw new Exception("NaviXupdater missing listId or cookie");
@@ -116,13 +114,13 @@ public class ChannelNaviXUpdate {
 		String s=ChannelUtil.postPage(u.openConnection(), query,naviCookie,null);
 		Channels.debug("navixup res "+s);
 	}
-	
+
 	public static void updatePlx(String name,String url) throws Exception {
 		String query="action=item_save&id=0&list_id="+listId+"&text_local=0&"+
 			"list_pos=top&type=plx&name="+ChannelUtil.escape(name)+"&URL="+ChannelUtil.escape(url);
 		upload(query);
 	}
-	
+
 	public static void sync(String name,String url,String proc,int format,
 			String thumb,String imdb) throws Exception {
 		if(ChannelUtil.empty(proc)) // just to make sure
@@ -166,7 +164,7 @@ public class ChannelNaviXUpdate {
 		"&description="+ChannelUtil.escape(imdb);
 		upload(query);
 	}
-	
+
 	public static void updateMedia(Channel ch,String name,String url,String proc,int format,
 			String thumb,String imdb) throws Exception {
 		if(local) {
@@ -175,11 +173,11 @@ public class ChannelNaviXUpdate {
 		if(netActive())
 			sync(name,url,proc,format,thumb,imdb);
 	}
-	
+
 	public static boolean netActive() {
 		return (!ChannelUtil.empty(listId))&&(!ChannelUtil.empty(naviCookie));
 	}
-	
+
 	public static boolean active() {
 		return local||netActive();
 	}

--- a/src/com/sharkhunter/channel/ChannelNullPlayer.java
+++ b/src/com/sharkhunter/channel/ChannelNullPlayer.java
@@ -7,37 +7,31 @@ import java.util.ArrayList;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.dlna.DLNAMediaInfo;
-import net.pms.dlna.DLNAMediaSubtitle;
 import net.pms.dlna.DLNAResource;
 import net.pms.encoders.FFMpegVideo;
-import net.pms.encoders.MEncoderWebVideo;
-import net.pms.formats.v2.SubtitleUtils;
 import net.pms.io.OutputParams;
 import net.pms.io.PipeProcess;
 import net.pms.io.ProcessWrapper;
 import net.pms.io.ProcessWrapperImpl;
 import net.pms.util.CodecUtil;
-import net.pms.util.FileUtil;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class ChannelNullPlayer extends FFMpegVideo {
 
 	private boolean transcode;
 	private PmsConfiguration configuration;
-	private boolean wmv; 	
-	
+	private boolean wmv;
+
 	public ChannelNullPlayer(boolean transcode) {
 		super();
 		configuration=PMS.getConfiguration();
 		this.transcode=transcode||Channels.cfg().mp2Force();
 		wmv=false;
 	}
-	
+
 	public String name() {
 		return "Channel Null Player";
 	}
-	
+
 	private void addMencoder(ArrayList<String> args,String in,File subFile) {
 		int nThreads = configuration.getMencoderMaxThreads();
 		String acodec = (configuration.isMencoderAc3Fixed() ? "ac3_fixed" : "ac3")+":abitrate=128" ;
@@ -49,7 +43,7 @@ public class ChannelNullPlayer extends FFMpegVideo {
 		args.add("-prefer-ipv4");
 		args.add("-cookies-file");
 		args.add(Channels.cfg().getCookiePath());
-		
+
 		args.add("-oac");
 		if(!transcode)
 			args.add("pcm");
@@ -104,7 +98,7 @@ public class ChannelNullPlayer extends FFMpegVideo {
 
 		}
 	}
-	
+
 	public ProcessWrapper launchTranscode(
 			DLNAResource dlna,
 			DLNAMediaInfo media,
@@ -120,15 +114,15 @@ public class ChannelNullPlayer extends FFMpegVideo {
 				wmv=true;
 				transcode=true;
 			}
-			
+
 			PipeProcess pipe = new PipeProcess("channels" + System.currentTimeMillis());
 			params.input_pipes[0] = pipe;
-				
+
 			ArrayList<String> args=new ArrayList<String>();
 			ChannelMediaStream cms=(ChannelMediaStream)dlna;
 			String format=ChannelUtil.extension(cms.realFormat(),true);
-			String effFile=fileName;
-			
+			//String effFile=fileName;
+
 			if (Channels.cfg().fileBuffer()) {
 				String fName=Channels.fileName(dlna.getName(),true);
 				if(cms.saveName()!=null)
@@ -156,22 +150,22 @@ public class ChannelNullPlayer extends FFMpegVideo {
 		    	// delay until file is large enough
 		    	while(m.length()<params.minBufferSize)
 		    		ChannelUtil.sleep(200);
-		    	effFile=m.getAbsolutePath();
+		    	//effFile=m.getAbsolutePath();
 			}
-			
-			
+
+
 			/*if(subs) { // subtitles use menocder
 				addMencoder(args,effFile,params.sid.getExternalFile());
 				args.add("-o");
 				args.add(params.input_pipes[0].getInputPipe());
-				
+
 			}
 			else {*/
 			if(subs) {
 				addMencoder(args,fileName,params.sid.getExternalFile());
 				args.add("-o");
 				args.add("-");
-			}	
+			}
 				String src=fileName;
 				args.add(configuration.getFfmpegPath());
 				if(fileName.startsWith("rtmpdump://channel?")) {
@@ -245,19 +239,18 @@ public class ChannelNullPlayer extends FFMpegVideo {
 				/*}
 				else {
 					addMencoder(args,fileName,null);
-					args.add("-o");	
+					args.add("-o");
 					args.add(params.input_pipes[0].getInputPipe());
 				}
 				}*/
-			
+
 			String[] cmdArray=new String[args.size()];
 			args.toArray(cmdArray);
-			
+
 			ProcessWrapper mkfifo_process = null;
 			mkfifo_process = params.input_pipes[0].getPipeProcess();
 
 			cmdArray = finalizeTranscoderArgs(
-				this,
 				fileName,
 				dlna,
 				media,
@@ -274,7 +267,7 @@ public class ChannelNullPlayer extends FFMpegVideo {
 			} catch (InterruptedException e) {
 			}
 			params.input_pipes[0].deleteLater();
-			
+
 			pw.runInNewThread();
 			try {
 				Thread.sleep(50);

--- a/src/com/sharkhunter/channel/ChannelOffHour.java
+++ b/src/com/sharkhunter/channel/ChannelOffHour.java
@@ -1,13 +1,9 @@
 package com.sharkhunter.channel;
 
-import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -15,33 +11,29 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
-import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import net.pms.PMS;
 import net.pms.encoders.Player;
 import net.pms.encoders.PlayerFactory;
-import net.pms.io.OutputParams;
-import net.pms.io.ProcessWrapper;
 
 public class ChannelOffHour {
-	
+
 	private HashMap<String,String> urls2fetch;
 	private ArrayList<Thread> threads;
 	private long startedAt;
-	
+
 	// Values of when to fetch etc.
 	private int maxParralell;
 	private int duration;
 	private GregorianCalendar nextTime;
 	private File file;
 	private boolean cache;
-	
+
 	// Constants
 	public static final int DEFAULT_MAX_THREAD=2;
 	public static final int DEFAULT_MAX_DURATION=60;
-	
+
 	public ChannelOffHour(int max,int dur,String start,File f,boolean cache) {
 		maxParralell=max;
 		duration=dur;
@@ -53,7 +45,7 @@ public class ChannelOffHour {
 		setStartTime(start);
 		schedule(true);
 	}
-	
+
 	public void schedule(boolean first) {
 		final ChannelOffHour inst=this;
 		TimerTask task = new TimerTask() {
@@ -74,7 +66,7 @@ public class ChannelOffHour {
 		Timer time=new Timer();
 		time.schedule(task, nextTime.getTime());
 	}
-	
+
 	private void setStartTime(String start) {
 		SimpleDateFormat sdfHour = new SimpleDateFormat("HH:mm");
 		try {
@@ -95,12 +87,12 @@ public class ChannelOffHour {
 		if(now.after(nextTime.getTime())) // already missed first trigger, schedule tomorrow
 			nextTime.add(Calendar.DATE, 1);
 	}
-	
+
 	private Date getNextTime() {
 		nextTime.add(Calendar.DATE, 1);
 		return nextTime.getTime();
 	}
-	
+
 	public void update(String url,String name,boolean add) {
 		if(add)
 			urls2fetch.put(name,url);
@@ -109,15 +101,15 @@ public class ChannelOffHour {
 		Channels.debug((add?"Added":"Removed")+" "+name+"("+url+") to off hour schedule");
 		storeDb();
 	}
-	
+
 	public boolean scheduled(String name) {
 		return urls2fetch.containsKey(name);
 	}
-	
+
 	public void init() {
 		if(!file.exists()) // no file, bail out early
 			return;
-		try {	
+		try {
 			BufferedReader in=new BufferedReader(new FileReader(file));
 			String str;
 			while ((str = in.readLine()) != null) {
@@ -134,7 +126,7 @@ public class ChannelOffHour {
 			Channels.debug("Error reading offhour file "+e);
 		}
 	}
-	
+
 	public void monitorThread() {
 		if(threads.size()==0) // no threads, no idea to monitor
 			return;
@@ -145,8 +137,8 @@ public class ChannelOffHour {
 				long now=System.currentTimeMillis();
 				// time to quit, leave all threads running
 				// until they're done
-				if(now>stop) 
-					return;			
+				if(now>stop)
+					return;
 				ArrayList<Thread> tmp=new ArrayList<Thread>(threads);
 				for(int i=0;i<tmp.size();i++) {
 					Thread t1=tmp.get(i);
@@ -174,7 +166,7 @@ public class ChannelOffHour {
 		Timer t=new Timer();
 		t.schedule(task, gc.getTime());
 	}
-	
+
 	public void startThread(String name,String url) {
 		Thread t=ChannelUtil.backgroundDownload(name,url,cache);
 		if(t==null)
@@ -182,7 +174,7 @@ public class ChannelOffHour {
 		threads.add(t);
 		t.start();
 	}
-	
+
 	public void startFetch() {
 		if(urls2fetch.size()==0) // nothing to do
 			return;
@@ -201,7 +193,7 @@ public class ChannelOffHour {
 			urls2fetch.remove(starts.get(i));
 		storeDb();
 	}
-	
+
 	private String[] getKeyVal() {
 		for(String name : urls2fetch.keySet()) {
 			String v=urls2fetch.get(name);
@@ -213,7 +205,7 @@ public class ChannelOffHour {
 		}
 		return null;
 	}
-	
+
 	private Player getPMSEnc() {
 		ArrayList<Player> pls=PlayerFactory.getPlayers();
 		for(int i=0;i<pls.size();i++) {
@@ -222,7 +214,7 @@ public class ChannelOffHour {
 		}
 		return null;
 	}
-	
+
 	private void storeDb() {
 		try {
 			FileOutputStream out=new FileOutputStream(file);

--- a/src/com/sharkhunter/channel/ChannelPMSAllPlay.java
+++ b/src/com/sharkhunter/channel/ChannelPMSAllPlay.java
@@ -2,15 +2,14 @@ package com.sharkhunter.channel;
 
 import java.io.InputStream;
 
-import net.pms.dlna.DLNAResource;
 import net.pms.dlna.virtual.VirtualFolder;
 
 public class ChannelPMSAllPlay extends VirtualFolder {
-	
+
 	public ChannelPMSAllPlay(String name,String thumb) {
 		super(name+" - ALL",thumb);
 	}
-	
+
 	public InputStream getThumbnailInputStream() {
 		try {
 			return downloadAndSend(thumbnailIcon,true);
@@ -19,7 +18,7 @@ public class ChannelPMSAllPlay extends VirtualFolder {
 			return super.getThumbnailInputStream();
 		}
 	}
-	
+
 	public void clearID() {
 		setId(null);
 	}

--- a/src/com/sharkhunter/channel/ChannelPMSFolder.java
+++ b/src/com/sharkhunter/channel/ChannelPMSFolder.java
@@ -2,37 +2,34 @@ package com.sharkhunter.channel;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-
 import org.apache.commons.lang.StringEscapeUtils;
 
-import net.pms.dlna.DLNAResource;
 import net.pms.dlna.virtual.VirtualFolder;
 import net.pms.dlna.virtual.VirtualVideoAction;
 
 public class ChannelPMSFolder extends VirtualFolder implements ChannelFilter{
-	
+
 		private ChannelFolder cf;
 		private String filter;
 		private String url;
 		private String imdb;
 		private String embSubs;
-		
+
 		private boolean thumbScriptRun;
 		private boolean favorized;
-		
+
 		public ChannelPMSFolder(ChannelFolder cf,char ch) {
 			this(cf,String.valueOf(ch),String.valueOf(ch),"",cf.getThumb());
 		}
-		
+
 		public ChannelPMSFolder(ChannelFolder cf,String name) {
 			this(cf,name,null,"",cf.getThumb());
 		}
-		
+
 		public ChannelPMSFolder(ChannelFolder cf,char ch,String url) {
 			this(cf,String.valueOf(ch),String.valueOf(ch),url,cf.getThumb());
 		}
-		
+
 		public ChannelPMSFolder(ChannelFolder cf,String name,String filter,String url,String thumb) {
 			super(name==null?"":StringEscapeUtils.unescapeHtml(name),thumb);
 			this.cf=cf;
@@ -42,15 +39,15 @@ public class ChannelPMSFolder extends VirtualFolder implements ChannelFilter{
 			thumbScriptRun=false;
 			embSubs="";
 		}
-		
+
 		public void setImdb(String imdb) {
 			this.imdb=imdb;
 		}
-		
+
 		public void setEmbSubs(String s) {
 			embSubs=s;
 		}
-		
+
 		public void discoverChildren() {
 			try {
 				if(!thumbScriptRun) {
@@ -88,20 +85,20 @@ public class ChannelPMSFolder extends VirtualFolder implements ChannelFilter{
 			} catch (Exception e) {
 			}
 		}
-		
+
 		public String getURL() {
 			return url;
 		}
-		
+
 		public void resolve() {
-			this.discovered=false;
+			this.setDiscovered(false);
 			this.getChildren().clear();
 		}
-		
+
 		public boolean isTranscodeFolderAvailable() {
 			return false;
 		}
-		
+
 		public boolean filter(String str) {
 			if(ChannelUtil.empty(filter))
 				return true;
@@ -110,15 +107,15 @@ public class ChannelPMSFolder extends VirtualFolder implements ChannelFilter{
 			}
 			return str.startsWith(filter);
 		}
-		
+
 		public String getThumb() {
 			return (thumbnailIcon);
 		}
-		
+
 		public ChannelFolder getFolder() {
 			return cf;
 		}
-		
+
 		public InputStream getThumbnailInputStream() {
 			try {
 				//thumbnailIcon=ChannelNaviXProc.simple(thumbnailIcon, cf.thumbScript());
@@ -130,13 +127,13 @@ public class ChannelPMSFolder extends VirtualFolder implements ChannelFilter{
 				return super.getThumbnailInputStream();
 			}
 		}
-		
+
 		private boolean monitor() {
 			return cf.getProperty("monitor");
 		}
-		
+
 		public void bookmark() {
-			if(cf.ignoreFav()||favorized) 
+			if(cf.ignoreFav()||favorized)
 				return;
 			favorized=true;
 			if(cf.isFavorized(name))
@@ -151,12 +148,12 @@ public class ChannelPMSFolder extends VirtualFolder implements ChannelFilter{
 				}
 			}
 		}
-		
+
 		public void unbookmark() {
 			ChannelUtil.RemoveFromFavFile(name,cf.getURL());
 			cf.remove();
 		}
-		
+
 		public boolean lastThumb() {
 			return (cf.getProp("last_thumb")!=null);
 		}

--- a/src/com/sharkhunter/channel/ChannelPMSSaveFolder.java
+++ b/src/com/sharkhunter/channel/ChannelPMSSaveFolder.java
@@ -9,7 +9,7 @@ import net.pms.dlna.virtual.VirtualVideoAction;
 import net.pms.formats.Format;
 
 public class ChannelPMSSaveFolder extends VirtualFolder {
-	
+
 	private Channel ch;
 	private String url;
 	private String name;
@@ -25,7 +25,7 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 	private String videoFormat;
 	private String embedSub;
 	private HashMap<String,String> stash;
-	
+
 	private static final String P="PLAY";
 	private static final String SP="PLAY&SAVE";
 	private static final String NS=" - No Subs";
@@ -34,9 +34,9 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 	private static final String SNS=SP+NS;
 	private static final String PES=P+ES;
 	private static final String SES=SP+ES;
-	
+
 	private static final long AUTO_PLAY_FACTOR=(1000*15);
-	
+
 	public ChannelPMSSaveFolder(Channel ch,String name,String url,String thumb,
 								String proc,int asx,int type,
 								ChannelScraper scraper) {
@@ -56,7 +56,7 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 		videoFormat=null;
 		embedSub=null;
 	}
-	
+
 	public static String washName(String str) {
 		String[] strs={SNS,PNS,SP,P,PES,SES};
 		for(String s : strs) {
@@ -65,34 +65,34 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 		}
 		return str;
 	}
-	
+
 	public void setImdb(String i) {
 		imdb=i;
 	}
-	
+
 	public void setDoSubs(boolean b) {
 		subs=b;
 	}
-	
+
 	public void setSaveMode(boolean raw) {
 		rawSave=raw;
 	}
-	
+
 	public void setEmbedSub(String str) {
 		embedSub=str;
 	}
-	
+
 	public void setStash(HashMap<String,String> map) {
 		stash=map;
 	}
-	
+
 	private String displayName(String n) {
 		if(Channels.cfg().longSaveName())
 			return ChannelUtil.append(n, " ", name);
 		else
 			return n;
 	}
-		
+
 	public void discoverChildren() {
 		final ChannelPMSSaveFolder me=this;
 		final ChannelOffHour oh=Channels.getOffHour();
@@ -170,7 +170,7 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 												   thumb,proc,f,asx,scraper,name,name);
 						cms.setEmbedSub(embedSub);
 						cms.setImdb(imdb);
-						cms.setRender(this.defaultRenderer);
+						cms.setRender(getDefaultRenderer());
 						cms.setSaveMode(rawSave);
 						cms.setFallbackFormat(videoFormat);
 						cms.setStreamVars(streamVars);
@@ -181,7 +181,7 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 										       proc,f,asx,scraper,name,null);
 					cms.setEmbedSub(embedSub);
 					cms.setImdb(imdb);
-					cms.setRender(this.defaultRenderer);
+					cms.setRender(getDefaultRenderer());
 					cms.setSaveMode(rawSave);
 					cms.setFallbackFormat(videoFormat);
 					cms.setStreamVars(streamVars);
@@ -203,14 +203,14 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 					subSel.setStreamVars(streamVars);
 					addChild(subSel);
 				}
-			}				
+			}
 		}
 		// add the no subs variants
 		if(save) {
 			cms=new ChannelMediaStream(ch,displayName(SNS),url,
 					   thumb,proc,f,asx,scraper,name,name);
 			cms.setImdb(imdb);
-			cms.setRender(this.defaultRenderer);
+			cms.setRender(getDefaultRenderer());
 			cms.setSaveMode(rawSave);
 			cms.setFallbackFormat(videoFormat);
 			cms.setStreamVars(streamVars);
@@ -221,7 +221,7 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 		cms=new ChannelMediaStream(ch,displayName(PNS),url,thumb,
 				proc,f,asx,scraper,name,null);
 		cms.setImdb(imdb);
-		cms.setRender(this.defaultRenderer);
+		cms.setRender(getDefaultRenderer());
 		cms.setSaveMode(rawSave);
 		cms.setFallbackFormat(videoFormat);
 		cms.setStreamVars(streamVars);
@@ -230,7 +230,7 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 		addChild(cms);
 	}
 
-	
+
 	public InputStream getThumbnailInputStream() {
 		try {
 			return downloadAndSend(thumbnailIcon,true);
@@ -239,30 +239,30 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 			return super.getThumbnailInputStream();
 		}
 	}
-	
+
 	public void childDone() {
 		//childDone=System.currentTimeMillis();
 	}
-	
+
 	public boolean preventAutoPlay() {
 		// Normally childDone is 0 and 0+15000 is never larger
 		// then now.
 		return (childDone+AUTO_PLAY_FACTOR)>System.currentTimeMillis();
 	}
-	
+
 	public void setFallbackFormat(String s) {
 		videoFormat=s;
 	}
-	
+
 	public boolean isRefreshNeeded() {
 		return true;
 	}
-    
+
     public boolean refreshChildren() {
     	refreshChildren(null);
     	return true;
     }
-	
+
 	public boolean refreshChildren(String str) {
 		if(str==null)
 			return false;
@@ -270,11 +270,11 @@ public class ChannelPMSSaveFolder extends VirtualFolder {
 		//discoverChildren(str);
 		return true;
 	}
-	
+
 	public void resolve() {
 		setDiscovered(false);
 	}
-	
+
 	public void addChild(DLNAResource child) {
 		if(Channels.cfg().stdAlone()) {
 			// be brutal

--- a/src/com/sharkhunter/channel/ChannelPMSSubSelector.java
+++ b/src/com/sharkhunter/channel/ChannelPMSSubSelector.java
@@ -5,14 +5,13 @@ import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import net.pms.dlna.DLNAMediaSubtitle;
 import org.apache.commons.lang.StringUtils;
 
 import net.pms.dlna.DLNAResource;
 import net.pms.dlna.virtual.VirtualFolder;
 
 public class ChannelPMSSubSelector extends VirtualFolder {
-	
+
 	private Channel ch;
 	private String name;
 	private String url;
@@ -28,18 +27,18 @@ public class ChannelPMSSubSelector extends VirtualFolder {
 
 	private String matchName;
 	private String site;
-	
+
 	private ChannelStreamVars streamVars;
-	
+
 	private static final String PNS="PLAY (no subs match)";
-	
+
 	public ChannelPMSSubSelector(Channel ch,String name,String nextUrl,
 				 String thumb,String proc,int type,int asx,
 				 ChannelScraper scraper,String dispName,
 				 String saveName,String imdb) {
 		this(ch,name,nextUrl,thumb,proc,type,asx,scraper,dispName,saveName,imdb,null);
 	}
-	
+
 	public ChannelPMSSubSelector(Channel ch,String name,String nextUrl,
 			  					 String thumb,String proc,int type,int asx,
 			  					 ChannelScraper scraper,String dispName,
@@ -61,14 +60,14 @@ public class ChannelPMSSubSelector extends VirtualFolder {
 		site=null;
 		streamVars=null;
 	}
-	
+
 	public void setSite(String s) {
 		site=s;
 		ChannelSubs subs=Channels.getSubs(site);
 		if(!ChannelUtil.empty(subs.getImg()))
 			thumbnailIcon=subs.getImg();
 	}
-	
+
 	public void setStreamVars(ChannelStreamVars vars) {
 		streamVars=vars;
 	}
@@ -120,7 +119,7 @@ public class ChannelPMSSubSelector extends VirtualFolder {
 		cms.setStreamVars(streamVars);
 		addChild(cms);
 	}
-	
+
 	public InputStream getThumbnailInputStream() {
 		try {
 			return downloadAndSend(thumbnailIcon,true);
@@ -128,8 +127,8 @@ public class ChannelPMSSubSelector extends VirtualFolder {
 		catch (Exception e) {
 			return super.getThumbnailInputStream();
 		}
-	}	
-	
+	}
+
 	private TreeMap<Integer,TreeSet<String>> sortMap(HashMap<String,Object> map) {
 		if(ChannelUtil.empty(matchName)) // make matchName ain't null
 			matchName="";

--- a/src/com/sharkhunter/channel/ChannelProxy.java
+++ b/src/com/sharkhunter/channel/ChannelProxy.java
@@ -1,7 +1,6 @@
 package com.sharkhunter.channel;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -10,12 +9,12 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 
 public class ChannelProxy {
-	
+
 	public static final int PROXY_NULL=-1;
 	public static final int PROXY_HTTP=0;
-	
+
 	public static ChannelProxy NULL_PROXY=new ChannelProxy();
-	
+
 	private Proxy p;
 	private boolean state;
 	private long lastCheck;
@@ -23,16 +22,16 @@ public class ChannelProxy {
 	private int type;
 	private String extra;
 	private String url;
-	
+
 	private static final long VerifyInterval=(60*1000*5);
-	
+
 	public ChannelProxy() {
 		p=Proxy.NO_PROXY;
 		state=true;
 		ia=null;
 		type=PROXY_NULL;
 	}
-	
+
 	public ChannelProxy(String name,ArrayList<String> data,File dPath) throws UnknownHostException {
 		String addr=null,port=null;
 		p=null;
@@ -61,7 +60,7 @@ public class ChannelProxy {
 		InetAddress ia=InetAddress.getByName(addr);
 		p=new Proxy(Proxy.Type.HTTP,(SocketAddress)new InetSocketAddress(ia,j.intValue()));
 	}
-	
+
 	public boolean isUp() {
 		if(type==PROXY_NULL)
 			return true;
@@ -73,19 +72,19 @@ public class ChannelProxy {
 		} catch (IOException e) {
 			state=false;
 		}*/
-		state=true;	
+		state=true;
 		lastCheck=System.currentTimeMillis();
 		return state;
 	}
-	
+
 	public int type() {
 		return type;
 	}
-	
+
 	public Proxy getProxy() {
 		return p;
 	}
-	
+
 	public void invalidate() {
 		if(type==PROXY_NULL) // impossible to invalidate
 			return;

--- a/src/com/sharkhunter/channel/ChannelScraper.java
+++ b/src/com/sharkhunter/channel/ChannelScraper.java
@@ -2,13 +2,11 @@ package com.sharkhunter.channel;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
-
 import net.pms.configuration.RendererConfiguration;
 import net.pms.dlna.DLNAResource;
 
-public interface ChannelScraper {	
-	public String scrape(Channel ch,String url,String processorUrl,int format,DLNAResource start, 
+public interface ChannelScraper {
+	public String scrape(Channel ch,String url,String processorUrl,int format,DLNAResource start,
 			             boolean noSub,String imdb,Object embedSubs,
 			             HashMap<String,String> extraMap,RendererConfiguration render);
 	public long delay();

--- a/src/com/sharkhunter/channel/ChannelSearch.java
+++ b/src/com/sharkhunter/channel/ChannelSearch.java
@@ -1,10 +1,7 @@
 package com.sharkhunter.channel;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.util.ArrayList;
 
 import net.pms.dlna.virtual.VirtualFolder;
@@ -16,7 +13,7 @@ public class ChannelSearch extends VirtualFolder {
 	private File file;
 	private boolean all;
 	ChannelSearchItem last;
-	
+
 	public ChannelSearch(File f) {
 		super("Recent Searches",null);
 		searchList=new ArrayList<ChannelSearchItem>();
@@ -24,7 +21,7 @@ public class ChannelSearch extends VirtualFolder {
 		all=true;
 		last=null;
 	}
-	
+
 	public void dump() {
 		if(all) {
 			try {
@@ -55,7 +52,7 @@ public class ChannelSearch extends VirtualFolder {
 		all=false;
 		last=null;
 	}
-	
+
 	private ChannelSearchItem findItem(Channel ch,String id,String str) {
 		ChannelSearchItem old=null;
 		for(int i=0;i<searchList.size();i++) {
@@ -72,13 +69,13 @@ public class ChannelSearch extends VirtualFolder {
 		}
 		return old;
 	}
-	
+
 	private void addItem(Channel ch,String id,String str) {
 		ChannelSearchItem item=new ChannelSearchItem(id,str,ch);
 		last=item;
 		searchList.add(item);
 	}
-	
+
 	public void addSearch(Channel ch,String id,String str) {
 		if(ChannelUtil.empty(id)) // no id give up early
 			return;
@@ -99,7 +96,7 @@ public class ChannelSearch extends VirtualFolder {
 		// time to create new item
 		addItem(ch,id,str);
 	}
-	
+
 	public void discoverChildren() {
 		for(int i=0;i<searchList.size();i++) {
 			addChild(searchList.get(i));

--- a/src/com/sharkhunter/channel/ChannelSimple.java
+++ b/src/com/sharkhunter/channel/ChannelSimple.java
@@ -3,34 +3,32 @@ package com.sharkhunter.channel;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
-
-import net.pms.PMS;
+import org.slf4j.LoggerFactory;
 
 public class ChannelSimple implements ChannelProps {
-	
+
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ChannelSimple.class);
 	private String name;
 	private String url;
-	private int format;
-	private int type;
 	private String[] prop;
-	
+
 	private ChannelMatcher matcher;
 	private Channel parent;
-	
+
 	public ChannelSimple(ArrayList<String> data,Channel parent) {
 		this.parent=parent;
 		parse(data);
 	}
-	
+
 	public ChannelSimple(Channel parent) {
 		this.parent=parent;
 	}
-	
+
 	public void setProp(String p) {
 		prop=p.trim().split(",");
 	}
-	
-	public void parse(ArrayList<String> data) {		
+
+	public void parse(ArrayList<String> data) {
 		for(int i=0;i<data.size();i++) {
 			String line=data.get(i).trim();
 			if(line==null)
@@ -44,13 +42,13 @@ public class ChannelSimple implements ChannelProps {
 				if(m!=null)
 					parse(m.getMacro());
 				else
-					PMS.debug("unknown macro "+keyval[1]);
-			}	
+					LOGGER.debug("{Channel} Unknown macro {}", keyval[1]);
+			}
 			if(keyval[0].equalsIgnoreCase("name"))
 				name=keyval[1];
 			if(keyval[0].equalsIgnoreCase("url"))
-				url=keyval[1];		
-			if(keyval[0].equalsIgnoreCase("prop"))	
+				url=keyval[1];
+			if(keyval[0].equalsIgnoreCase("prop"))
 				prop=keyval[1].trim().split(",");
 			if(keyval[0].equalsIgnoreCase("matcher")) {
 				if(matcher==null)
@@ -70,11 +68,11 @@ public class ChannelSimple implements ChannelProps {
 		if(matcher!=null)
 			matcher.processProps(prop);
 	}
-	
+
 	public ChannelMatcher getMatcher() {
 		return matcher;
 	}
-	
+
 	public String fetch() {
 		try {
 			URL urlobj=new URL(url.replaceAll(" ", "%20"));
@@ -89,18 +87,18 @@ public class ChannelSimple implements ChannelProps {
 	public String separator(String base) {
 		return ChannelUtil.getPropertyValue(prop, base+"_separator");
 	}
-	
+
 	public boolean onlyFirst() {
 		return ChannelUtil.getProperty(prop, "only_first");
 	}
-	
+
 	public String append(String base) {
 		return ChannelUtil.getPropertyValue(prop,"append_"+base);
 	}
 	public String prepend(String base) {
 		return ChannelUtil.getPropertyValue(prop,"prepend_"+base);
 	}
-	
+
 	@Override
 	public boolean escape(String base) {
 		return ChannelUtil.getProperty(prop, base+"_escape");

--- a/src/com/sharkhunter/channel/ChannelStreamVars.java
+++ b/src/com/sharkhunter/channel/ChannelStreamVars.java
@@ -2,48 +2,50 @@ package com.sharkhunter.channel;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.ArrayList;
-import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
-
-import net.pms.PMS;
+import org.slf4j.LoggerFactory;
 import net.pms.dlna.DLNAResource;
 import net.pms.io.OutputParams;
 
 public class ChannelStreamVars {
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(ChannelStreamVars.class);
 	private HashMap<String,ChannelVar> vars;
 	private String instance;
-	
+
 	public ChannelStreamVars() {
 		vars=new HashMap<String,ChannelVar>();
 	}
-	
+
 	public ChannelStreamVars(ChannelStreamVars def) {
 		vars=new HashMap<String,ChannelVar>(def.vars);
 		instance=def.instance;
 	}
-	
+
 	public void parse(File f) throws Exception {
-		BufferedReader in=new BufferedReader(new FileReader(f));
     	String str,ver="unknown";
     	StringBuilder sb=new StringBuilder();
-    	while ((str = in.readLine()) != null) {
-    		str=str.trim();
-    		if(ChannelUtil.ignoreLine(str))
-				continue;
-    		if(str.startsWith("version")) {
-    			String[] v=str.split("\\s*=\\s*");
-     	    	if(v.length<2)
-     	    		continue;
-     	    	ver=v[1];
-     	    	continue; // don't append these
-     	    }	
-    		sb.append(str);
-     	    sb.append("\n");
-    	}
+		BufferedReader in=new BufferedReader(new FileReader(f));
+		try {
+	    	while ((str = in.readLine()) != null) {
+	    		str=str.trim();
+	    		if(ChannelUtil.ignoreLine(str))
+					continue;
+	    		if(str.startsWith("version")) {
+	    			String[] v=str.split("\\s*=\\s*");
+	     	    	if(v.length<2)
+	     	    		continue;
+	     	    	ver=v[1];
+	     	    	continue; // don't append these
+	     	    }
+	    		sb.append(str);
+	     	    sb.append("\n");
+	    	}
+		} finally {
+			in.close();
+		}
     	String[] lines=sb.toString().split("\n");
     	for(int i=0;i<lines.length;i++) {
     	    str=lines[i].trim();
@@ -54,10 +56,10 @@ public class ChannelStreamVars {
     			vars.put(v.displayName(), v);
     	    }
     	}
-    	PMS.minimal("Adding stream vars version "+ver);
+    	LOGGER.debug("{Channel} Adding stream vars version {}", ver);
     	Channels.debug("Adding stream vars version "+ver);
 	}
-	
+
 	public void add(DLNAResource res,Channel ch) {
 		for(String var: vars.keySet()) {
 			ChannelVar v=vars.get(var);
@@ -73,22 +75,22 @@ public class ChannelStreamVars {
 			res.addChild(new ChannelPMSVar(var,v));
 		}
 	}
-	
+
 	public void resolve(String player,List<String> list,OutputParams params) {
 		for(String var: vars.keySet()) {
 			ChannelVar v=vars.get(var);
 			v.action(player,list,params);
 		}
 	}
-	
+
 	public void setInstance(int i) {
 		setInstance(String.format("%x", i));
 	}
-	
+
 	public void setInstance(String inst) {
 		instance=inst;
 	}
-	
+
 	public String instance() {
 		return instance;
 	}

--- a/src/com/sharkhunter/channel/ChannelSubUtil.java
+++ b/src/com/sharkhunter/channel/ChannelSubUtil.java
@@ -2,15 +2,13 @@ package com.sharkhunter.channel;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 
 import net.pms.dlna.DLNAResource;
 
 public class ChannelSubUtil {
-	
+
 	private final static String ARROW =" --> ";
 
 	public static String backtrackedName(DLNAResource start,String[] prop) {
@@ -24,7 +22,7 @@ public class ChannelSubUtil {
 
 	public static HashMap<String,Object> subSelect(DLNAResource start,String imdb,
 			String[] subtitle,Channel ch,String realName) {
-		if(subtitle==null) 
+		if(subtitle==null)
 			return null;
 		for(int i=0;i<subtitle.length;i++) {
 			ChannelSubs subs=Channels.getSubs(subtitle[i]);
@@ -83,7 +81,7 @@ public class ChannelSubUtil {
 	}
 
 	public static ArrayList<String> subSites(String[] subtitle) {
-		if(subtitle==null) 
+		if(subtitle==null)
 			return null;
 		ArrayList<String> res=new ArrayList<String>();
 		for(int i=0;i<subtitle.length;i++) {
@@ -98,7 +96,7 @@ public class ChannelSubUtil {
 			res.add(Channels.openSubs().getName());
 		return res;
 	}
-	
+
 	private static String fixTimeNormal(String str) {
 		int pos=str.lastIndexOf(':');
 		if(pos==-1)
@@ -107,7 +105,7 @@ public class ChannelSubUtil {
 		sb.setCharAt(pos, ',');
 		return sb.toString();
 	}
-	
+
 	private static String fixTimeMs(String str) {
 		long millis=Long.parseLong(str);
 		long sec,min,hour;
@@ -119,18 +117,18 @@ public class ChannelSubUtil {
 		millis = millis % 1000;
 		return String.format("%02d:%02d:%02d,%03d", hour,min,sec,millis);
 	}
-	
+
 	private static String fixTime(String str,boolean ms) {
 		if(ms)
 			return fixTimeMs(str);
 		else
 			return fixTimeNormal(str);
 	}
-	
+
 	public static void writeSRT(OutputStreamWriter out,int id,String start,String stop,String text) throws IOException {
 		writeSRT(out,id,start,stop,text,false);
 	}
-	
+
 	public static void writeSRT(OutputStreamWriter out,int id,String start,String stop,String text,boolean ms) throws IOException {
 		text=text.trim().replaceAll("\\\\n", "\n");
 		out.write(String.valueOf(id));

--- a/src/com/sharkhunter/channel/ChannelSubs.java
+++ b/src/com/sharkhunter/channel/ChannelSubs.java
@@ -1,37 +1,25 @@
 package com.sharkhunter.channel;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import net.pms.PMS;
-import net.pms.dlna.DLNAResource;
-import net.pms.formats.Format;
-import net.pms.formats.v2.SubtitleType;
 
 public class ChannelSubs implements ChannelProps {
-	
+
 	private String name;
 	private String url;
 	private ChannelMatcher matcher;
 	private int best;
-	private int pathCnt;
 	private String[] prop;
 	private File dPath;
 	private String script;
@@ -39,7 +27,7 @@ public class ChannelSubs implements ChannelProps {
 	private String[] lang;
 	private ChannelMatcher select;
 	protected String img;
-	
+
 	public ChannelSubs() {
 		prop=null;
 		dPath=new File(Channels.dataPath());
@@ -93,14 +81,14 @@ public class ChannelSubs implements ChannelProps {
 				if(best<1)
 					best=1;
 			}
-			if(keyval[0].equalsIgnoreCase("prop"))	
-				prop=keyval[1].trim().split(",");	
+			if(keyval[0].equalsIgnoreCase("prop"))
+				prop=keyval[1].trim().split(",");
 			if(keyval[0].equalsIgnoreCase("name_script")) {
 				nameScript=keyval[1].split(",");
 			}
 			if(keyval[0].equalsIgnoreCase("script")) {
 				script=keyval[1];
-			}	
+			}
 			if(keyval[0].equalsIgnoreCase("lang")) {
 				lang=keyval[1].trim().split(",");
 			}
@@ -113,19 +101,19 @@ public class ChannelSubs implements ChannelProps {
 		if(matcher!=null)
 			matcher.processProps(prop);
 	}
-	
+
 	public String getName() {
 		return name;
 	}
-	
+
 	public void setName(String name) {
 		this.name=name;
 	}
-	
+
 	public String getImg() {
 		return img;
 	}
-	
+
 	private String rarFile(File f) {
 		boolean concat=ChannelUtil.getProperty(prop, "rar_concat");
 		boolean keep=ChannelUtil.getProperty(prop, "rar_keep");
@@ -150,7 +138,7 @@ public class ChannelSubs implements ChannelProps {
 				if(concat) {
 					if(first) {
 						fName=(f.getAbsolutePath()+".srt").replace(".rar", "");
-						fos = new FileOutputStream(fName);		
+						fos = new FileOutputStream(fName);
 					}
 				}
 				else {
@@ -179,7 +167,7 @@ public class ChannelSubs implements ChannelProps {
 			return null;
 		return cacheFile(new File(firstName));
 	}
-	
+
 	private String zipFile(File f) {
 		boolean concat=ChannelUtil.getProperty(prop, "zip_concat");
 		boolean keep=ChannelUtil.getProperty(prop, "zip_keep");
@@ -208,12 +196,12 @@ public class ChannelSubs implements ChannelProps {
 					continue;
 				if(rename) {
 					String i=first?"":"_"+String.valueOf(id++);
-					fName=dPath+File.separator+i+entry.getName();		
+					fName=dPath+File.separator+i+entry.getName();
 				}
 				if(concat) {
 					if(first) {
 						fName=(f.getAbsolutePath()+".srt").replace(".zip", "");
-						FileOutputStream fos1 = new FileOutputStream(fName);		
+						FileOutputStream fos1 = new FileOutputStream(fName);
 						dest = new BufferedOutputStream(fos1, BUFFER);
 					}
 				}
@@ -231,7 +219,7 @@ public class ChannelSubs implements ChannelProps {
 				if(!concat) {
 					dest.flush();
 					dest.close();
-				}	
+				}
 			}
 			if(concat) {
 				dest.flush();
@@ -241,24 +229,24 @@ public class ChannelSubs implements ChannelProps {
 			if(!keep)
 				f.delete();
 			return cacheFile(new File(firstName)); // return the first name no matter what
-		} 
+		}
 		catch (Exception e) {
 			Channels.debug("error "+e+" reading zipped subtile");
 			return null;
 		}
 	}
-	
+
 	private String cacheFile(File f) {
 		ChannelUtil.cacheFile(f,"sub");
 		return f.getAbsolutePath();
 	}
-	
+
 	public String getSubs(String mediaName) {
 		HashMap<String,String> map=new HashMap<String,String>();
 		map.put("url", mediaName);
 		return getSubs(map);
 	}
-	
+
 	public String getSubs(HashMap<String,String> map) {
 		String mediaName=map.get("url");
 		Channels.debug("get subs "+mediaName);
@@ -290,7 +278,7 @@ public class ChannelSubs implements ChannelProps {
 		boolean rar=ChannelUtil.getProperty(prop, "rar_force");
 		return downloadSubs(subUrl,path,zip,rar);
 	}
-	
+
 	public static String downloadSubs(String subUrl) {
 		int pos=subUrl.lastIndexOf('/');
 		String name="sub_"+System.currentTimeMillis();
@@ -298,16 +286,16 @@ public class ChannelSubs implements ChannelProps {
 			name=subUrl.substring(pos+1);
 		return downloadSubs(subUrl,name);
 	}
-	
+
 	public static String downloadSubs(String subUrl,String name) {
 		name=name.replaceAll("[\\?&=;,]", "").replace('/', '_').replace('\\', '_');
 		String path=Channels.dataPath()+File.separator+name+".srt";
 		ChannelSubs nullSub=new ChannelSubs();
 		return nullSub.downloadSubs(subUrl,path,false,false);
-		
+
 	}
-	
-	
+
+
 	private String downloadSubs(String subUrl,String path, boolean zip,boolean rar) {
 		File f=new File(path);
 		if(f.exists())
@@ -327,7 +315,7 @@ public class ChannelSubs implements ChannelProps {
 			return rarFile(f);
 		return cacheFile(f);
 	}
-	
+
 	private String getMediaName(String mediaName,HashMap<String,String> map) {
 		if(nameScript!=null) {
 			String nScript=nameScript[0];
@@ -343,12 +331,12 @@ public class ChannelSubs implements ChannelProps {
 			}
 			else
 				mediaName=ChannelUtil.escape(mediaName);
-		}	
+		}
 		else
 			mediaName=ChannelUtil.escape(mediaName);
 		return mediaName;
 	}
-	
+
 	public String fetchSubsUrl(HashMap<String,String> map) {
 		String mediaName=map.get("url").trim();
 		mediaName=getMediaName(mediaName,map);
@@ -362,7 +350,7 @@ public class ChannelSubs implements ChannelProps {
 			Channels.debug("subs page "+page);
 			if(ChannelUtil.empty(page))
 				return null;
-			if(!ChannelUtil.empty(script)) { // we got a script, we'll use it 
+			if(!ChannelUtil.empty(script)) { // we got a script, we'll use it
 				ArrayList<String> s=Channels.getScript(script);
 				if(s!=null) {
 					HashMap<String,String> res=ChannelNaviXProc.lite(page, s,map);
@@ -386,7 +374,7 @@ public class ChannelSubs implements ChannelProps {
 		}
 		return null;
 	}
-	
+
 	public HashMap<String,Object> select(HashMap<String,String> map) {
 		if(select==null)
 			return null;
@@ -434,15 +422,15 @@ public class ChannelSubs implements ChannelProps {
 		if(obj instanceof String)
 			return icon;
 		ChannelSubSelected css=(ChannelSubSelected)obj;
-		if(ChannelUtil.empty(css.lang)) 
+		if(ChannelUtil.empty(css.lang))
 			return icon;
 		return "/resource/images/codes/"+ChannelISO.iso(css.lang, 3)+".png";
 	}
-	
+
 	public String resolve(ChannelSubSelected css) {
 		return "";
 	}
-	
+
 	public static String resolve(Object obj) {
 		if(obj instanceof String)
 			return downloadSubs((String)obj);
@@ -459,7 +447,7 @@ public class ChannelSubs implements ChannelProps {
 			else
 				return downloadSubs(css.url,css.name);
 		ArrayList<String> s=Channels.getScript(css.script);
-		if(s==null) 
+		if(s==null)
 			return null;
 		HashMap<String,String> map=new HashMap<String,String>();
 		map.put("select", "true");
@@ -474,25 +462,25 @@ public class ChannelSubs implements ChannelProps {
 		else
 			return downloadSubs(subUrl,css.name);
 	}
-	
+
 	public boolean langSupported() {
 		return !ChannelUtil.empty(langPrefered());
 	}
-	
+
 	public String langPrefered() {
 		if(lang==null)
 			return null;
 		String[] langCode=PMS.getConfiguration().getSubtitlesLanguages().split(",");
 		if(lang[0].equals("all"))
 			return langCode[0];
-		for(int j=0;j<langCode.length;j++) 
-			for(int i=0;i<lang.length;i++) 
+		for(int j=0;j<langCode.length;j++)
+			for(int i=0;i<lang.length;i++)
 				if(ChannelISO.equal(langCode[j],lang[i]))
 					return lang[i];
 		return null;
 	}
-	
-	
+
+
 	@Override
 	public boolean onlyFirst() {
 		return false;
@@ -512,7 +500,7 @@ public class ChannelSubs implements ChannelProps {
 	public String prepend(String base) {
 		return null;
 	}
-	
+
 	@Override
 	public boolean escape(String base) {
 		return false;
@@ -523,11 +511,11 @@ public class ChannelSubs implements ChannelProps {
 	public boolean unescape(String base) {
 		return false;
 	}
-	
+
 	public String mangle(String base) {
 		return ChannelUtil.getPropertyValue(prop, base+"_mangle");
 	}
-	
+
 	public boolean selectable() {
 		return (select!=null);
 	}

--- a/src/com/sharkhunter/channel/ChannelUtil.java
+++ b/src/com/sharkhunter/channel/ChannelUtil.java
@@ -1,20 +1,13 @@
 package com.sharkhunter.channel;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
@@ -26,9 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
 import org.apache.commons.io.FileUtils;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
@@ -39,36 +29,36 @@ import net.pms.formats.Format;
 import net.pms.io.OutputParams;
 
 public class ChannelUtil {
-	
+
 	// Misc constants
-	
+
 	public static final String defAgentString="Mozilla/5.0 (Windows; U; Windows NT 6.1; sv-SE; rv:1.9.2.3) Gecko/20100409 Firefox/3.7.3";
-	
+
 	// ASX types
 	public static final int ASXTYPE_NONE=0;
 	public static final int ASXTYPE_AUTO=1;
 	public static final int ASXTYPE_FORCE=2;
 
-	
+
 	public static String postPage(URLConnection connection,String query) {
 		return postPage(connection,query,"",null);
 	}
-	
+
 	public static String postPage(URLConnection connection,String query,String cookie,
-								  HashMap<String,String> hdr) {   
+								  HashMap<String,String> hdr) {
 		URL url=connection.getURL();
-		connection.setDoOutput(true);   
-		connection.setDoInput(true);   
-		connection.setUseCaches(false);   
-		connection.setDefaultUseCaches(false);   
-		//connection.setAllowUserInteraction(true);   
+		connection.setDoOutput(true);
+		connection.setDoInput(true);
+		connection.setUseCaches(false);
+		connection.setDefaultUseCaches(false);
+		//connection.setAllowUserInteraction(true);
 
 		connection.setRequestProperty ("Content-Type", "application/x-www-form-urlencoded");
 		connection.setRequestProperty("User-Agent",defAgentString);
 		if(query==null)
 			query="";
-		connection.setRequestProperty("Content-Length", "" + query.length());  
-		
+		connection.setRequestProperty("Content-Length", "" + query.length());
+
 		try {
 			String c1=ChannelCookie.getCookie(url.toString());
 			if(!empty(c1)) {
@@ -78,7 +68,7 @@ public class ChannelUtil {
 			if(!empty(cookie))
 				connection.setRequestProperty("Cookie",cookie);
 			if(hdr!=null&&hdr.size()!=0) {
-				for(String key : hdr.keySet()) 
+				for(String key : hdr.keySet())
 					connection.setRequestProperty(key,hdr.get(key));
 			}
 			connection.setConnectTimeout(10000);
@@ -87,8 +77,8 @@ public class ChannelUtil {
 			// open up the output stream of the connection
 			if(!empty(query)) {
 				DataOutputStream output = new DataOutputStream(connection.getOutputStream());
-				output.writeBytes(query);   
-				output.flush ();   
+				output.writeBytes(query);
+				output.flush ();
 				output.close();
 			}
 
@@ -110,15 +100,15 @@ public class ChannelUtil {
 			return "";
 		}
 	}
-	
+
 	public static String fetchPage(URLConnection connection) {
 		return fetchPage(connection,null,"",null);
 	}
-	
+
 	public static String fetchPage(URLConnection connection,ChannelAuth auth,String cookie) {
 		return fetchPage(connection,auth,cookie,null);
 	}
-	
+
 	public static String fetchPage(URLConnection connection,ChannelAuth auth,String cookie,HashMap<String,String> hdr) {
 		try {
 //			URLConnection connection=url.openConnection();
@@ -129,7 +119,7 @@ public class ChannelUtil {
 				Channels.debug("auth "+auth.method+" authstr "+auth.authStr);
 				if(auth.method==ChannelLogin.STD)
 					connection.setRequestProperty("Authorization", auth.authStr);
-				else if(auth.method==ChannelLogin.COOKIE) 
+				else if(auth.method==ChannelLogin.COOKIE)
 					cookie=append(cookie,"; ",auth.authStr);
 				else if(auth.method==ChannelLogin.APIKEY) {
 					url=new URL(url.toString()+auth.authStr);
@@ -147,10 +137,10 @@ public class ChannelUtil {
 			if(!empty(cookie))
 				connection.setRequestProperty("Cookie",cookie);
 			if(hdr!=null&&hdr.size()!=0) {
-				for(String key : hdr.keySet()) 
+				for(String key : hdr.keySet())
 					connection.setRequestProperty(key,hdr.get(key));
 			}
-		//	connection.setRequestProperty("Content-Length", "0"); 
+		//	connection.setRequestProperty("Content-Length", "0");
 			connection.setDoInput(true);
 			connection.setDoOutput(true);
 			BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
@@ -171,7 +161,7 @@ public class ChannelUtil {
 			return "";
 		}
 	}
-	
+
 	public static boolean cookieContains(String cookie1,String cookie0) {
 		if(empty(cookie0))
 			return false;
@@ -187,7 +177,7 @@ public class ChannelUtil {
 		}
 		return false;
 	}
-	
+
 	public static boolean downloadText(InputStream in,File f) throws Exception {
 		String subcp=getCodePage();
 		OutputStreamWriter out=new OutputStreamWriter(new FileOutputStream(f),subcp);
@@ -205,11 +195,11 @@ public class ChannelUtil {
 		in.close();
 		return true;
 	}
-	
+
 	public static boolean downloadBin(String url,File f) {
 		return downloadBin(url,f,false);
 	}
-	
+
 	public static boolean downloadBin(String url,File f,boolean text) {
 		try {
 			URL u=new URL(url);
@@ -242,11 +232,11 @@ public class ChannelUtil {
 		}
 		return false;
 	}
-	
+
 	public static boolean empty(String s) {
 		return (s==null)||(s.length()==0);
 	}
-	
+
 	private static String findProperty(String[] props,String prop) {
 		if(props==null)
 			return null;
@@ -256,7 +246,7 @@ public class ChannelUtil {
 		}
 		return null;
 	}
-	
+
 	public static String getPropertyValue(String[] props,String prop) {
 		String s=findProperty(props,prop);
 		if(s==null)
@@ -266,11 +256,11 @@ public class ChannelUtil {
 			return null;
 		return ss[1];
 	}
-	
+
 	public static boolean getProperty(String[] props,String prop) {
 		return (findProperty(props,prop)!=null);
 	}
-	
+
 	public static ArrayList<String> gatherBlock(String[] lines,int start) {
 		ArrayList<String> res=new ArrayList<String>();
 		int curls=1;
@@ -289,7 +279,7 @@ public class ChannelUtil {
 		}
 		return res;
 	}
-	
+
 	public static ArrayList<String> gatherBlock(ArrayList<String> data,int start) {
 		ArrayList<String> res=new ArrayList<String>();
 		int curls=1;
@@ -308,7 +298,7 @@ public class ChannelUtil {
 		}
 		return res;
 	}
-	
+
 	public static String append(String res,String sep,String data) {
 		res=ChannelUtil.separatorToken(res);
 		data=ChannelUtil.separatorToken(data);
@@ -321,18 +311,18 @@ public class ChannelUtil {
 			return res+data;
 		return res+sep+data;
 	}
-	
+
 	public static ChannelMacro findMacro(ArrayList<ChannelMacro> macros,String macro) {
 		if(macros==null)
 			return null;
-		for(int i=0;i<macros.size();i++) { 	
+		for(int i=0;i<macros.size();i++) {
 			ChannelMacro m=macros.get(i);
 			if(m!=null&&macro.equals(m.getName()))
 				return m;
 		}
 		return null;
 	}
-	
+
 	public static String getThumb(String thumb,String pThumb,Channel ch) {
 		if(!empty(thumb))  // if the thumb we found is good use it
 			return thumb;
@@ -342,18 +332,18 @@ public class ChannelUtil {
 			return ch.getThumb();
 		return null;
 	}
-	
+
 	public static String pendData(String src,String[] props,String field,String sep) {
 		String p=getPropertyValue(props,"prepend_"+field);
 		String a=getPropertyValue(props,"append_"+field);
 		Channels.debug("prepend "+p+" append "+a+" src "+src+" f "+field);
 		return append(p,sep,append(src,sep,a));
 	}
-	
+
 	public static String pendData(String src,String[] props,String field) {
 		return pendData(src,props,field,null);
 	}
-	
+
 	public static String concatField(String conf,String matched,String[] props,String field) {
 		String cProp=getPropertyValue(props,"concat_"+field);
 		if(cProp==null)
@@ -366,7 +356,7 @@ public class ChannelUtil {
 			return append(matched,sep,conf);
 		return matched;
 	}
-	
+
 	public static String concatURL(String a,String b) {
 		if(empty(a))
 			return b;
@@ -380,13 +370,13 @@ public class ChannelUtil {
 			return a+"/"+b;*/
 		return a+b;
 	}
-	
+
 	public static boolean ignoreLine(String line) {
 		if(empty(line))
 			return true;
 		return (line.charAt(0)=='#');
 	}
-	
+
 	public static String parseASX(String url, int type) {
 		if(type==ChannelUtil.ASXTYPE_NONE)
 			return url;
@@ -408,11 +398,11 @@ public class ChannelUtil {
 			return url;
 		return page.substring(first+6,last);
 	}
-	
+
 	public static boolean isASX(String str) {
 		return (str!=null&&str.endsWith(".asx"));
 	}
-	
+
 	public static int calcCont(String[] props) {
 		String lim=ChannelUtil.getPropertyValue(props, "continue_limit");
 		int ret=Channels.DeafultContLim;
@@ -420,18 +410,18 @@ public class ChannelUtil {
 			try {
 				ret=Integer.parseInt(lim);
 			}
-			catch (Exception e) { 
+			catch (Exception e) {
 			}
 		}
 		if(ret<0)
 			ret=Channels.DeafultContLim;
 		return ret;
 	}
-	
+
 	public static String extension(String fileName) {
 		return extension(fileName,false);
 	}
-	
+
 	public static String extension(String fileName,boolean stripDot) {
 		if(ChannelUtil.empty(fileName))
 			return null;
@@ -440,7 +430,7 @@ public class ChannelUtil {
 			return fileName.substring(pos+(stripDot?1:0));
 		return null;
 	}
-	
+
 	public static String guessExt(String fileName,String url) {
 		if(!empty(extension(fileName)))
 			return fileName;
@@ -452,7 +442,7 @@ public class ChannelUtil {
 		// No extension, give up
 		return fileName;
 	}
-	
+
 	public static String unescape(String str) {
 		try {
 			return URLDecoder.decode(str,"UTF-8");
@@ -461,7 +451,7 @@ public class ChannelUtil {
 		}
 		return str;
 	}
-	
+
 	public static String escape(String str) {
 		try {
 			return URLEncoder.encode(str,"UTF-8");
@@ -470,11 +460,11 @@ public class ChannelUtil {
 		}
 		return str;
 	}
-	
+
 	public static boolean rtmpStream(String url) {
 		return streamType(url,"rtmp");
 	}
-	
+
 	public static boolean streamType(String url,String type) {
 		try {
 			URI u=new URI(url);
@@ -485,7 +475,7 @@ public class ChannelUtil {
 			return false;
 		}
 	}
-	
+
 	private static String addSubs(String rUrl,String sub,Channel ch,
 								  RendererConfiguration render) {
 		boolean braviaFix = false;
@@ -512,11 +502,11 @@ public class ChannelUtil {
 	  //  rUrl=append(rUrl,"&subdelay=","20000");
 		return rUrl;
 	}
-	
+
 	public static String badResource() {
 		return "resource://"+ChannelResource.redXUrl();
 	}
-	
+
 	public static String createMediaUrl(String url,int format,Channel ch,
 			RendererConfiguration render) {
 		//Channels.debug("create media url entry(str only) "+url);
@@ -524,7 +514,7 @@ public class ChannelUtil {
 		map.put("url", url);
 		return createMediaUrl(map,format,ch,render);
 	}
-	
+
 	public static String createMediaUrl(HashMap<String,String> vars,int format,
 										Channel ch,RendererConfiguration render) {
 		if(!empty(vars.get("bad"))) {
@@ -536,18 +526,18 @@ public class ChannelUtil {
 			return null;
 		rUrl=rUrl.replace("HTTP://", "http://"); // ffmpeg has problems with ucase HTTP
 		int rtmpMet=Channels.rtmpMethod();
-		String type=vars.get("__type__");			
+		String type=vars.get("__type__");
 		Channels.debug("create media url entry "+rUrl+" format "+format+" type "+type);
 		if(rUrl.startsWith("http")) {
 			if((format!=Format.VIDEO)||
-			   (rtmpMet==Channels.RTMP_MAGIC_TOKEN))    
+			   (rtmpMet==Channels.RTMP_MAGIC_TOKEN))
 				return rUrl;
 			//rUrl="navix://channel?url="+escape(rUrl);
 			rUrl="channel?url="+escape(rUrl);
 			String agent=vars.get("agent");
 			if(empty(agent))
 				agent=ChannelUtil.defAgentString;
-			rUrl=append(rUrl,"&agent=",escape(agent));	
+			rUrl=append(rUrl,"&agent=",escape(agent));
 			if(!empty(vars.get("referer")))
 				rUrl=append(rUrl,"&referer=",escape(vars.get("referer")));
 			String sub=vars.get("subtitle");
@@ -565,7 +555,7 @@ public class ChannelUtil {
 			Channels.debug("return media url "+rUrl);
 			return rUrl;
 		}
-		
+
 		if(!empty(type)&&type.equals("RTMPDUMP")) {
 			Channels.debug("rmtpdump spec "+rUrl);
 			String[] args=rUrl.split("!!!");
@@ -589,7 +579,7 @@ public class ChannelUtil {
 			Channels.debug("return media url rtmpdump spec "+rUrl);
 			return rUrl;
 		}
-		
+
 		String[] s=rUrl.split(" ");
 		if(s.length>1) {
 			// This is likely rtmp from navix
@@ -602,18 +592,18 @@ public class ChannelUtil {
 					vars.put(ss[0].toLowerCase(), ss[1]);
 			}
 		}
-		
+
 		if(!rtmpStream(rUrl)) // type is sopcast etc.
 			return rUrl;
 		if(rUrl.startsWith("rtmpdump://"))
 			return rUrl;
-		
+
 		switch(rtmpMet) {
 			case Channels.RTMP_MAGIC_TOKEN:
 				rUrl=ChannelUtil.append(rUrl, "!!!pms_ch_dash_y!!!", vars.get("playpath"));
 				rUrl=ChannelUtil.append(rUrl, "!!!pms_ch_dash_w!!!", vars.get("swfVfy"));
 				break;
-			
+
 			case Channels.RTMP_DUMP:
 				Channels.debug("rtmpdump method");
 				rUrl="rtmpdump://channel?-r="+escape(rUrl);
@@ -632,7 +622,7 @@ public class ChannelUtil {
 					rUrl=addSubs(rUrl,sub,ch,render);
 				}
 				break;
-				
+
 			default:
 				rUrl=vars.get("url");
 				break;
@@ -640,7 +630,7 @@ public class ChannelUtil {
 		Channels.debug("return media url "+rUrl);
 		return rUrl;
 	}
-	
+
 	public static String rtmpOp(String op) {
 		if(op.equals("-r"))
 			return "";
@@ -655,19 +645,19 @@ public class ChannelUtil {
 		if(op.equals("--swfVfy"))
 			return "swfVfy";
 		return op;
-			
+
 	}
-	
+
 	private static boolean backTrackCompensate(DLNAResource start) {
 		// if we are in a subslector skip that
-		if(start instanceof ChannelPMSSubSelector) 
+		if(start instanceof ChannelPMSSubSelector)
 			return true;
 		// Sub sites should be skipped to
 		if(start instanceof ChannelPMSSubSiteSelector)
 			return true;
 		return false;
 	}
-	
+
 	public static String backTrack(DLNAResource start,int stop) {
 		if(start==null)
 			return null;
@@ -693,7 +683,7 @@ public class ChannelUtil {
 			return curr.getName();
 		return null;
 	}
-	
+
 	public static String backTrack(DLNAResource start,int[] stops,String sep) {
 		if(empty(sep))
 			sep=" ";
@@ -705,13 +695,13 @@ public class ChannelUtil {
 		}
 		return res;
 	}
-	
-	
+
+
 	public static String backTrack(DLNAResource start,int[] stops) {
 		return backTrack(start,stops, " ");
 	}
-	
-	
+
+
 	public static int[] getNameIndex(String[] prop) {
 		try {
 			String x=ChannelUtil.getPropertyValue(prop, "name_index");
@@ -731,7 +721,7 @@ public class ChannelUtil {
 		}
 		return null;
 	}
-	
+
 	public static String mangle(String re,String str) {
 		if(empty(re))
 			return str;
@@ -743,7 +733,7 @@ public class ChannelUtil {
 			res=res+m.group(i);
 		return res;
 	}
-	
+
 	public static String format2str(int format) {
 		switch(format) {
 		case Format.AUDIO:
@@ -756,20 +746,20 @@ public class ChannelUtil {
 			return "Unknown";
 		}
 	}
-	
+
 	public static String execute(String script,String url,int format) {
 		return execute(script,url,format2str(format));
 	}
-	
+
 	public static String execute(String script,String url,String format) {
 		ProcessBuilder pb=new ProcessBuilder(script,"\""+url+"\"",format);
 		return execute(pb);
 	}
-	
+
 	public static String execute(ProcessBuilder pb) {
 		return execute(pb,false);
 	}
-	
+
 	public static String execute(ProcessBuilder pb,boolean verbose) {
 		try {
 			Channels.debug("about to execute "+pb.command());
@@ -807,13 +797,13 @@ public class ChannelUtil {
 		catch (Exception e) {
 		}
 	}
-	
+
 	public static Thread backgroundDownload(String name,String url,boolean cache) {
 		String fName=ChannelUtil.guessExt(Channels.fileName(name, cache),
 				url);
 		if(ChannelUtil.rtmpStream(url)) {
 			try {
-				//		URL u=new URL(url); 
+				//		URL u=new URL(url);
 				// rtmp stream special fix
 				if(empty(extension(fName))) // no extension. Rtmp is normally mp4
 					fName=fName+".mp4";
@@ -832,7 +822,7 @@ public class ChannelUtil {
 				return null;
 			}
 		}
-		
+
 		String subFile="";
 		if(url.startsWith("http")||
 		   url.startsWith("navix")||
@@ -878,7 +868,7 @@ public class ChannelUtil {
 							// ignore this
 							Channels.debug("Error moving subtitle file "+sFile);
 						}
-					}					
+					}
 					// download the actaul movie, subtitles are done
 					downloadBin(rUrl,f);
 				}
@@ -887,7 +877,7 @@ public class ChannelUtil {
 		}
 		return null;
 	}
-	
+
 	private static ProcessBuilder buildPid(String fName,String url) {
 			int rtmpMet=Channels.rtmpMethod();
 			if(rtmpMet==Channels.RTMP_MAGIC_TOKEN) {
@@ -911,11 +901,11 @@ public class ChannelUtil {
 			args.add("\""+fName+"\"");
 			return new ProcessBuilder(args);
 	}
-	
+
 	public static int getFormat(String type) {
 		return getFormat(type,-1);
 	}
-	
+
 	public static int getFormat(String type,int def) {
 		if(type.equalsIgnoreCase("image"))
 			return Format.IMAGE;
@@ -925,7 +915,7 @@ public class ChannelUtil {
 			return Format.AUDIO;
 		return def;
 	}
- 
+
 	public static Proxy proxy(ChannelAuth a) {
 		if(a==null)
 			return Proxy.NO_PROXY;
@@ -933,7 +923,7 @@ public class ChannelUtil {
 			return Proxy.NO_PROXY;
 		return a.proxy.getProxy();
 	}
-	
+
 	public static String separatorToken(String str) {
 		if(str==null)
 			return null;
@@ -943,20 +933,20 @@ public class ChannelUtil {
 			return "\r\n";
 		return str;
 	}
-	
+
 	public static boolean cookieMethod(int method) {
 		return (method==ChannelLogin.COOKIE)||(method==ChannelLogin.SIMPLE_COOKIE);
 	}
-	
+
 	public static void list2file(StringBuilder sb,String[] list) {
 		for(int i=0;i<list.length;i++) {
 			sb.append(list[i]);
 			sb.append(",");
 		}
 	}
-	
-	public final static String FAV_BAR="\n############################\n"; 
-	
+
+	public final static String FAV_BAR="\n############################\n";
+
 	public static void addToFavFile(String data,String name,String owner) {
 		File f=Channels.workFavFile();
 		try {
@@ -966,7 +956,7 @@ public class ChannelUtil {
 				str=str+"## Auto generated favorite file,Edit with care\n\n\n";
 			}
 			else
-				str = FileUtils.readFileToString(f);	
+				str = FileUtils.readFileToString(f);
 			Channels.debug("adding to fav file "+name);
 			String n="## Name: "+name+",Owner: "+owner;
 			int pos = str.indexOf(n);
@@ -983,7 +973,7 @@ public class ChannelUtil {
 		catch (Exception e) {
 		}
 	}
-	
+
 	public static void RemoveFromFavFile(String name, String url) {
 		File f=Channels.workFavFile();
 		try {
@@ -1004,7 +994,7 @@ public class ChannelUtil {
 		catch (Exception e) {
 		}
 	}
-			
+
 	public static String type2str(int type) {
 		switch(type) {
 		case ChannelFolder.TYPE_ATZ:
@@ -1027,7 +1017,7 @@ public class ChannelUtil {
 			return "normal";
 		}
 	}
-	
+
 	public static String stripExt(String str,int cnt,String strip) {
 		if(cnt==0)
 			cnt=-1;
@@ -1039,29 +1029,29 @@ public class ChannelUtil {
 			cnt--;
 		}
 		return str;
-	} 
-	
+	}
+
 	public static void sleep(String time) {
 		try {
 			sleep(Long.parseLong(time));
 		}
-		catch (Exception e) { 
+		catch (Exception e) {
 		}
 	}
-	
+
 	public static void sleep(long time) {
 		try {
 			Thread.sleep(time);
 		}
 		catch (Exception e){}
 	}
-	
+
 	public static String ensureDot(String str) {
 		if(str.charAt(0)!='.')
 			return "."+str;
 		return str;
 	}
-	
+
 	public static List<String> addStreamVars(List<String> args,ChannelStreamVars streamVars,
 				OutputParams params) {
 		ArrayList<String> res=new ArrayList<String>();
@@ -1083,14 +1073,14 @@ public class ChannelUtil {
 		}
 		return res;
 	}
-	
+
 	public static String ensureImdbtt(String imdb) {
 		/*if(empty(imdb))
 			return imdb;
 		return (imdb.startsWith("tt")?imdb:"tt"+imdb);*/
 		return imdb;
 	}
-	
+
 	public static String trimURL(String url) {
 		String u1=url.replace("http://", "").replace("https://", "");
 		int p=u1.indexOf("/");
@@ -1101,7 +1091,7 @@ public class ChannelUtil {
 			u1=u1.substring(p+1);
 		return u1;
 	}
-	
+
 	public static void killThread(Thread t) {
 		if(t!=null) {
 			t.interrupt();
@@ -1111,10 +1101,10 @@ public class ChannelUtil {
 			}
 		}
 	}
-	
+
 	public static final String REL_HOST = "host";
 	public static final String REL_PATH = "path";
-	
+
 	public static String relativeURL(String rUrl,String pUrl,String relType) {
 		if(empty(relType)||
 		   empty(rUrl)||
@@ -1140,18 +1130,18 @@ public class ChannelUtil {
 		}
 		return rUrl;
 	}
-	
+
 	public static void appendVarLine(StringBuffer sb,String var,String val) {
 		sb.append(var);
 		sb.append("=");
 		sb.append(val.trim());
 		sb.append("\n");
 	}
-		
+
 	public static Thread newBackgroundDownload(final String name,String url) {
 		if(ChannelUtil.rtmpStream(url)) {
 			try {
-				//		URL u=new URL(url); 
+				//		URL u=new URL(url);
 				// rtmp stream special fix
 				final ProcessBuilder pb=buildPid(name,url);
 				if(pb==null)
@@ -1210,7 +1200,7 @@ public class ChannelUtil {
 							// ignore this
 							Channels.debug("Error moving subtitle file "+sFile);
 						}
-					}					
+					}
 					// download the actaul movie, subtitles are done
 					Channels.debug("rUrl "+rUrl);
 					if(rUrl.contains(".m3u8")) {
@@ -1242,11 +1232,11 @@ public class ChannelUtil {
 		}
 		return null;
 	}
-	
+
 	public static boolean filterInternals(DLNAResource r) {
 		return ((r instanceof VirtualVideoAction)||(r instanceof ChannelPMSAllPlay));
 	}
-	
+
 	public static String searchInPath(DLNAResource res) {
 		while(res!=null) {
 			if((res instanceof Search)) {
@@ -1258,7 +1248,7 @@ public class ChannelUtil {
 		}
 		return "";
 	}
-	
+
 	public static int convInt(String str,int def) {
 		try {
 			Integer i=Integer.valueOf(str);
@@ -1275,5 +1265,5 @@ public class ChannelUtil {
 			return "utf-8";
 		return cp;
 	}
-	
+
 }

--- a/src/com/sharkhunter/channel/Channels.java
+++ b/src/com/sharkhunter/channel/Channels.java
@@ -807,8 +807,14 @@ public class Channels extends VirtualFolder implements FileListener {
 
 	public static boolean readCookieFile(String file,HashMap<String,ArrayList<ChannelAuth>> map) {
 		boolean skipped=false;
+		File cookieFile = new File(file);
+		if (!cookieFile.exists()) {
+			LOGGER.debug("{Channel} Cookie file \"{}\" not found - skipping", file);
+			return true;
+		}
 		try {
-			BufferedReader in=new BufferedReader(new FileReader(file));
+
+			BufferedReader in=new BufferedReader(new FileReader(cookieFile));
 			try {
 				String str;
 		    	while ((str = in.readLine()) != null) {
@@ -874,6 +880,7 @@ public class Channels extends VirtualFolder implements FileListener {
 			out.close();
 		}
 		catch (Exception e) {
+			LOGGER.warn("{Channel} Error writing cookie file \"{}\": {}", file, e);
 			debug("Error writing cookie file "+e);
 		}
 	}

--- a/src/com/sharkhunter/channel/Search.java
+++ b/src/com/sharkhunter/channel/Search.java
@@ -4,44 +4,43 @@ import net.pms.dlna.virtual.*;
 
 public class Search extends VirtualFolder {
 	private SearchObj sobj;
-	private String name;
 	private StringBuilder sb;
-	private boolean searched; 
-	
-	
+	private boolean searched;
+
+
 	public Search(SearchObj obj) {
 		this(obj,"");
 	}
-	
+
 	public Search(SearchObj obj,String str) {
 		super(str,null);
 		this.sobj=obj;
 		this.sb=new StringBuilder(str);
 		searched=false;
 	}
-	
+
 	public String result() {
 		return sb.toString();
 	}
-	
+
 	public SearchObj getSearchObj() {
 		return sobj;
 	}
-	
+
 	public String getName() {
 		return sb.toString();
 	}
-	
+
 	public String getSystemName() {
 		return getName();
 	}
-	
+
 	public void resolve() {
-		discovered=false;
+		setDiscovered(false);
 	}
-	
+
 	public synchronized void append(char ch) {
-		if(ch=='\0') 
+		if(ch=='\0')
 			sb=new StringBuilder();
 		else if(ch=='\b') {
 			if(sb.length()!=0)
@@ -50,12 +49,12 @@ public class Search extends VirtualFolder {
 		else
 			this.sb.append(ch);
 	}
-	
+
 	public void discoverChildren() {
 		if(searched) {
 			getChildren().clear();
 		}
 		this.sobj.search(sb.toString(),this);
 		searched=true;
-	}	
+	}
 }

--- a/src/com/sharkhunter/channel/SearchAction.java
+++ b/src/com/sharkhunter/channel/SearchAction.java
@@ -14,25 +14,25 @@ public class SearchAction extends VirtualFolder {
 	public SearchAction(Search sobj,char ch) {
 		this(sobj,ch,String.valueOf(ch));
 	}
-	
+
 	public SearchAction(Search sobj,char ch,String name) {
 		super(name,"images/Play1Hot_120.jpg");
 		this.sobj=sobj;
 		this.ch=ch;
 		this.name=name;
 	}
-	
+
 	public InputStream getThumbnailInputStream() {
         return getResourceInputStream("images/Play1Hot_120.jpg");
 	}
-	
+
 	public void resolve() {
-		discovered=false;  // we can't clear this enough
+		setDiscovered(false);  // we can't clear this enough
 	}
-	
+
 	public void discoverChildren() {
 		sobj.append(ch);
-		discovered=false;
+		setDiscovered(false);
 	}
 
 	@Override
@@ -54,7 +54,7 @@ public class SearchAction extends VirtualFolder {
 	public long lastModified() {
 		return 0;
 	}
-	
+
 	 public String getThumbnailContentType() {
          return HTTPResource.JPEG_TYPEMIME;
 	 }

--- a/src/com/sharkhunter/channel/SearchFolder.java
+++ b/src/com/sharkhunter/channel/SearchFolder.java
@@ -1,22 +1,19 @@
 package com.sharkhunter.channel;
 
-import java.io.*;
-
 import net.pms.dlna.virtual.VirtualFolder;
-import net.pms.PMS;
 
 public class SearchFolder extends VirtualFolder {
 	private String name;
 	private SearchObj sobj;
 	private String result;
-	
+
 	public SearchFolder (String name,SearchObj sobj){
 		super(name,null);
 		this.name=name;
 		this.sobj=sobj;
 	}
-	
-	
+
+
 	private void createSearcher(SearchObj obj,String initStr) {
 		char i;
 		Search s=new Search(obj,initStr);
@@ -24,15 +21,15 @@ public class SearchFolder extends VirtualFolder {
 		addChild(new SearchAction(s,'\0',"Clear"));
 		addChild(new SearchAction(s,' ',"Space"));
 		addChild(new SearchAction(s,'\b',"Delete"));
-		for(i='A';i<='Z';i++) 
+		for(i='A';i<='Z';i++)
 			addChild(new SearchAction(s,i));
 		for(i='0';i<='9';i++)
 			addChild(new SearchAction(s,i));
 	}
-	
+
 	public void resolve() {
 	}
-	
+
 	public void discoverChildren(String str) {
 		Channels.debug("search "+str);
 		result=null;
@@ -43,29 +40,29 @@ public class SearchFolder extends VirtualFolder {
 			sobj.search(str, this);
 		}
 	}
-	
+
 	public String result() {
 		return result;
 	}
-	
+
 	public boolean isSearched() {
 		return true;
 	}
-	
+
 	//@Override
     public void discoverChildren()  {
 		createSearcher(sobj,"");
     }
-    
+
     public boolean isRefreshNeeded() {
 		return true;
 	}
-    
+
     public boolean refreshChildren() {
     	refreshChildren(null);
     	return true;
     }
-	
+
 	public boolean refreshChildren(String str) {
 		if(str==null)
 			return false;


### PR DESCRIPTION
I've updated all calls that's marked as deprecated by UMS to their modern day counterparts. I've also removed unused imports, fixed some memory leaks (opened streams not getting closed) and avoided an exception if the cookie file doesn't exist.

It all compiles and runs fine, and I can browse a bunch of folders, but I didn't understand enough about the configuration to actually test it playing anything. Except from that small bugfix, I haven't changed anything that should give any different results than before though.

